### PR TITLE
Ordering of navbarBackground properties

### DIFF
--- a/cosmo/variables.less
+++ b/cosmo/variables.less
@@ -181,8 +181,8 @@
 @navbarCollapseDesktopWidth:      @navbarCollapseWidth + 1;
 
 @navbarHeight:                    50px;
-@navbarBackgroundHighlight:       @navbarBackground;
 @navbarBackground:                @grayDarker;
+@navbarBackgroundHighlight:       @navbarBackground;
 @navbarBorder:                    transparent;
 
 @navbarText:                      @white;


### PR DESCRIPTION
There was an error in the ordering of the properties leading to compile errors, fixed it.
