### PR TITLE
Add bootstrap to .gitignore

### DIFF
--- a/swatchmaker/.gitignore
+++ b/swatchmaker/.gitignore
@@ -1,0 +1,1 @@
+bootstrap


### PR DESCRIPTION
I'm using bootswatch as a submodule & the repo shows up modified because of bootstrap. Could you add it to the .gitignore (or create a swatchmaker/.gitignore as per this pull)?
