### PR TITLE
Point to right URL for customisable variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Customization
 ------
 Bootswatch is an open source project, and you’re welcome to modify the themes further. If you’re interested, fork or follow the GitHub repository. The files of interest are in the `gh-pages` branch.
 
-Each raw theme consists of two LESS files. One is `variables.less`, which is included by default in Bootstrap and allows you to customize [these settings](http://twitter.github.com/bootstrap/less.html#variables). The other is called `bootswatch.less` and introduces more extensive structural changes.
+Each raw theme consists of two LESS files. One is `variables.less`, which is included by default in Bootstrap and allows you to customize [these settings](http://twitter.github.io/bootstrap/customize.html#variables). The other is called `bootswatch.less` and introduces more extensive structural changes.
 
 Check out the README in the [swatchmaker directory](https://github.com/thomaspark/bootswatch/tree/master/swatchmaker) for step-by-step instructions on building your own swatch.
 


### PR DESCRIPTION
Very minor thing; I noticed that the customisable settings URL was returning a 404, so I updated it with one that points to the right place.
