### PR TITLE
Added link to Grunt CLI in help index.html

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -104,7 +104,7 @@
               <li>
                 <p>Edit <code>variables.less</code> and <code>bootswatch.less</code> in one of the theme directories, or create your own in <code>/custom</code>.</p>
               </li>
-              <li><p>Type <code>grunt swatch:[theme]</code> to build the CSS for a theme, e.g., <code>grunt swatch:amelia</code> for Amelia. Or type <code>grunt swatch</code> to build them all at once.</p></li>
+              <li><p>Type <code>grunt swatch:[theme]</code> to build the CSS for a theme, e.g., <code>grunt swatch:amelia</code> for Amelia. Or type <code>grunt swatch</code> to build them all at once. To have <code>grunt</code> available in the command line, install <code>grunt-cli</code> as described on the <a href="http://gruntjs.com/getting-started">Grunt Getting Started page</a>.</p></li>
             </ol>
             <p>Here are additional tips for <a href="http://coding.smashingmagazine.com/2013/03/12/customizing-bootstrap/" target="_blank">customizing Bootstrap</a>.</p>
 


### PR DESCRIPTION
I thought this note on how to make Grunt work at the command line (or rather, a reference to it in the Grunt guide online) would be helpful to future readers.
