### PR TITLE
Enable livereload support for the watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-connect');
 
   // Project configuration.
   grunt.initConfig({
@@ -51,6 +52,15 @@ module.exports = function (grunt) {
       options: {
         livereload: true,
         nospawn: true
+      }
+    },
+    connect: {
+      all: {
+        options: {
+          port: 3000,
+          keepalive: true,
+          livereload: true
+        }
       }
     }
   });

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-less": "~0.9.0",
     "grunt-contrib-watch": "~0.5.1"
   }


### PR DESCRIPTION
Fixes #283.

Note that this first commit does not completely set up livereload for you. You must either use a livereload extension or manually add the livereload script to each HTML page.
