### PR TITLE
Fix for checkbox alignment

### DIFF
--- a/yeti/bootstrap.css
+++ b/yeti/bootstrap.css
@@ -2313,7 +2313,7 @@ input[type="search"] {
 }
 input[type="radio"],
 input[type="checkbox"] {
-  margin: 4px 0 0;
+  margin: 1px 0 0;
   margin-top: 1px \9;
   line-height: normal;
 }


### PR DESCRIPTION
As Yeti use a small font size (12px) instead of Bootstrap default font size (15px) for labels, this fix will ensure the proper alignment between the label and the checkbox for the basic form example described at http://getbootstrap.com/css/#forms.
