### PR TITLE
Remove content from progress bar

### DIFF
--- a/paper/bootswatch.less
+++ b/paper/bootswatch.less
@@ -289,7 +289,6 @@ select.form-control {
 
     &:last-child&:before {
       display: block;
-      content: 'div::before';
       position: absolute;
       width: 100%;
       height: 100%;


### PR DESCRIPTION
Remove ```content: 'div::before';``` from progress bar. It appears on the back of the progress bar.