### PR TITLE
Modal z-index fix

### DIFF
--- a/paper/variables.less
+++ b/paper/variables.less
@@ -265,7 +265,8 @@
 @zindex-popover:           1060;
 @zindex-tooltip:           1070;
 @zindex-navbar-fixed:      1030;
-@zindex-modal:             1040;
+@zindex-modal-background:  1040;
+@zindex-modal:             1050;
 
 
 //== Media queries breakpoints


### PR DESCRIPTION
Missing zindex-modal-background variable.

Without it, the modal background has a higher z index than modal

See here:

![bug-bootswatch-paper](https://cloud.githubusercontent.com/assets/1740540/5270943/ab94c642-7a3d-11e4-8d6f-9e3436089bed.png)
