### PR TITLE
Use CSS escape with 0\9 padding hack

### DIFF
--- a/paper/_bootswatch.scss
+++ b/paper/_bootswatch.scss
@@ -183,7 +183,7 @@ select.form-control {
   -moz-appearance: none;
   appearance: none;
   padding-left: 0;
-  padding-right: 0\9; // remove padding for < ie9 since default arrow can't be removed
+  padding-right: #{"0\9"}; // remove padding for < ie9 since default arrow can't be removed
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAJ1BMVEVmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmaP/QSjAAAADHRSTlMAAgMJC0uWpKa6wMxMdjkoAAAANUlEQVR4AeXJyQEAERAAsNl7Hf3X6xt0QL6JpZWq30pdvdadme+0PMdzvHm8YThHcT1H7K0BtOMDniZhWOgAAAAASUVORK5CYII=);
   background-size: 13px;
   background-repeat: no-repeat;

--- a/paper/bootswatch.less
+++ b/paper/bootswatch.less
@@ -183,7 +183,7 @@ select.form-control {
   -moz-appearance: none;
   appearance: none;
   padding-left: 0;
-  padding-right: 0\9; // remove padding for < ie9 since default arrow can't be removed
+  padding-right: ~"0\9"; // remove padding for < ie9 since default arrow can't be removed
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAJ1BMVEVmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmZmaP/QSjAAAADHRSTlMAAgMJC0uWpKa6wMxMdjkoAAAANUlEQVR4AeXJyQEAERAAsNl7Hf3X6xt0QL6JpZWq30pdvdadme+0PMdzvHm8YThHcT1H7K0BtOMDniZhWOgAAAAASUVORK5CYII=);
   background-size: 13px;
   background-repeat: no-repeat;


### PR DESCRIPTION
Hi,

I noticed that the padding hack in the latest Paper theme cases problems with alternative Less4J compiler. While this is a bug with Less4j (SomMeri/less4j#267), I think it would make sense to use CSS escaping, which works with less4j, with the hack.