### PR TITLE
Fix link to Mark Otto's GitHub Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Thomas Park
 
 Thanks
 ------
-[Mark Otto](https://github.com/markdotto) and [Jacob Thornton](https://github.com/fat) for [Bootstrap](https://github.com/twitter/bootstrap).
+[Mark Otto](https://github.com/mdo) and [Jacob Thornton](https://github.com/fat) for [Bootstrap](https://github.com/twitter/bootstrap).
 
 [Jenil Gogari](http://www.jgog.in/) for his contributions to the Flatly theme.
 


### PR DESCRIPTION
The link to Mark Otto's GitHub account is incorrect. This fixes it.