### PR TITLE
add a main for build systems

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,5 +39,8 @@
     "font-awesome": "~4.0.0",
     "html5shiv": "~3.7.0",
     "respond": "~1.4.2"
-  }
+  },
+  "main": [
+    "cerulean/bootstrap.css"
+  ]
 }


### PR DESCRIPTION
Set the default bower main method to Cerulean theme for wiredep (it was the first I saw). 

"main" method for bower 

Stack Overflow:
http://stackoverflow.com/questions/20391742/what-is-the-main-property-when-doing-bower-init

from: https://github.com/bower/bower.json-spec

main

Recommended
Type: String or Array of String

The entry-point files necessary to use your package. Only one file per filetype.
