### PR TITLE
Paper: Reset input-addon feedback styles.

### DIFF
--- a/paper/_bootswatch.scss
+++ b/paper/_bootswatch.scss
@@ -374,6 +374,15 @@ input[type="checkbox"],
   }
 }
 
+// Remove the Bootstrap feedback styles for input addons
+.input-group-addon {
+  .has-warning &, .has-error &, .has-success & {
+    color: $input-color;
+    border-color: $input-group-addon-border-color;
+    background-color: $input-group-addon-bg;
+  }
+}
+
 // Navs =======================================================================
 
 .nav-tabs {

--- a/paper/bootswatch.less
+++ b/paper/bootswatch.less
@@ -374,6 +374,15 @@ input[type="checkbox"],
   }
 }
 
+// Remove the Bootstrap feedback styles for input addons
+.input-group-addon {
+  .has-warning &, .has-error &, .has-success & {
+    color: @input-color;
+    border-color: @input-group-addon-border-color;
+    background-color: @input-group-addon-bg;
+  }
+}
+
 // Navs =======================================================================
 
 .nav-tabs {


### PR DESCRIPTION
#### Paper Theme

When using the various input feedback styles, `.has-warning`, `.has-error` and `.has-success`, Bootstrap applies a colored border and background to `.input-group-addon`s in `_forms.scss` which uses the brand colors styles directly and not dedicated variables.

This patch adds styles to `paper/_bootswatch.scss` and `paper/_bootswatch.less` to reset this using the input-addon variables used for the default addons without feedback. The result is that if there is feedback the input is underlined according to material rules and the addon is unaffected. I couldn't spot a Material Design rule for addons, but I think this works quite well. An alternative might be to have the font color of the addon change according to the feedback.

Tested for SASS; not tested for LESS, although it l think the change is straightforward and should work.