### PR TITLE
Fix libsass compilation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,8 +232,9 @@ grunt.registerTask('build_scss', 'build a regular theme from scss', function(the
                 .replace(/\.less/g, '')
                 // 11. replace icon-font-path value with conditional for asset helpers
                 .replace(/(\$icon-font-path:).*;/g, '$1 if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/bootstrap/");')
-                // 12. set bootswatch's web-font-path value as !default
-                .replace(/(\$web-font-path:.*);/g, '$1 !default;');
+                // 12. remove css import option
+                .replace(/@import \(css\)/g, '@import');
+
                 if (/\/variables.less$/.test(lessFile)) {
                 // 13. set default value of $bootstrap-sass-asset-helper to false
                   out = "$bootstrap-sass-asset-helper: false;\n" + out;

--- a/cosmo/_bootswatch.scss
+++ b/cosmo/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/cosmo/_variables.scss
+++ b/cosmo/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" !default;
 
 //== Colors
 //

--- a/cosmo/bootswatch.less
+++ b/cosmo/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/cosmo/variables.less
+++ b/cosmo/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700";
 
 //== Colors
 //

--- a/cyborg/_bootswatch.scss
+++ b/cyborg/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/cyborg/_variables.scss
+++ b/cyborg/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,700" !default;
 
 //== Colors
 //

--- a/cyborg/bootswatch.less
+++ b/cyborg/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/cyborg/variables.less
+++ b/cyborg/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,700";
 
 //== Colors
 //

--- a/darkly/_bootswatch.scss
+++ b/darkly/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/darkly/_variables.scss
+++ b/darkly/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic" !default;
 
 //== Colors
 //

--- a/darkly/bootswatch.less
+++ b/darkly/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/darkly/variables.less
+++ b/darkly/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
 
 //== Colors
 //

--- a/flatly/_bootswatch.scss
+++ b/flatly/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/flatly/_variables.scss
+++ b/flatly/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic" !default;
 
 //== Colors
 //

--- a/flatly/bootswatch.less
+++ b/flatly/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/flatly/variables.less
+++ b/flatly/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
 
 //== Colors
 //

--- a/journal/_bootswatch.scss
+++ b/journal/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=News+Cycle:400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/journal/_variables.scss
+++ b/journal/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=News+Cycle:400,700" !default;
 
 //== Colors
 //

--- a/journal/bootswatch.less
+++ b/journal/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=News+Cycle:400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/journal/variables.less
+++ b/journal/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=News+Cycle:400,700";
 
 //== Colors
 //

--- a/lumen/_bootswatch.scss
+++ b/lumen/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 @mixin shadow($width: 4px){
   border-width: 0 1px $width 1px;

--- a/lumen/_variables.scss
+++ b/lumen/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic" !default;
 
 //== Colors
 //

--- a/lumen/bootswatch.less
+++ b/lumen/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 .shadow (@width: 4px) {
   border-width: 0 1px @width 1px;

--- a/lumen/variables.less
+++ b/lumen/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic";
 
 //== Colors
 //

--- a/paper/_bootswatch.scss
+++ b/paper/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/paper/_variables.scss
+++ b/paper/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" !default;
 
 //== Colors
 //

--- a/paper/bootswatch.less
+++ b/paper/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/paper/variables.less
+++ b/paper/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700";
 
 //== Colors
 //

--- a/readable/_bootswatch.scss
+++ b/readable/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/readable/_variables.scss
+++ b/readable/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700" !default;
 
 //== Colors
 //

--- a/readable/bootswatch.less
+++ b/readable/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/readable/variables.less
+++ b/readable/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700";
 
 //== Colors
 //

--- a/sandstone/_bootswatch.scss
+++ b/sandstone/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,500" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/sandstone/_variables.scss
+++ b/sandstone/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,500" !default;
 
 //== Colors
 //

--- a/sandstone/bootswatch.less
+++ b/sandstone/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,500";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/sandstone/variables.less
+++ b/sandstone/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,500";
 
 //== Colors
 //

--- a/simplex/_bootswatch.scss
+++ b/simplex/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 @mixin btn-shadow($color){
   @include gradient-vertical-three-colors(lighten($color, 3%), $color, 6%, darken($color, 3%));

--- a/simplex/_variables.scss
+++ b/simplex/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700" !default;
 
 //== Colors
 //

--- a/simplex/bootswatch.less
+++ b/simplex/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 .btn-shadow(@color) {
   #gradient > .vertical-three-colors(lighten(@color, 3%), @color, 6%, darken(@color, 3%));

--- a/simplex/variables.less
+++ b/simplex/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700";
 
 //== Colors
 //

--- a/spacelab/_bootswatch.scss
+++ b/spacelab/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 @mixin btn-shadow($color){
   @include gradient-vertical-three-colors(lighten($color, 15%), $color, 50%, darken($color, 4%));

--- a/spacelab/_variables.scss
+++ b/spacelab/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700" !default;
 
 //== Colors
 //

--- a/spacelab/bootswatch.less
+++ b/spacelab/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 .btn-shadow(@color) {
   #gradient > .vertical-three-colors(lighten(@color, 15%), @color, 50%, darken(@color, 4%));

--- a/spacelab/variables.less
+++ b/spacelab/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700";
 
 //== Colors
 //

--- a/superhero/_bootswatch.scss
+++ b/superhero/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/superhero/_variables.scss
+++ b/superhero/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700" !default;
 
 //== Colors
 //

--- a/superhero/bootswatch.less
+++ b/superhero/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/superhero/variables.less
+++ b/superhero/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700";
 
 //== Colors
 //

--- a/united/_bootswatch.scss
+++ b/united/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/united/_variables.scss
+++ b/united/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700" !default;
 
 //== Colors
 //

--- a/united/bootswatch.less
+++ b/united/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/united/variables.less
+++ b/united/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700";
 
 //== Colors
 //

--- a/yeti/_bootswatch.scss
+++ b/yeti/_bootswatch.scss
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" !default;
-
-@mixin web-font($path){
-  @import url("#{$path}");
-}
-@include web-font($web-font-path);
+@import url("#{$web-font-path}");
 
 // Navbar =====================================================================
 

--- a/yeti/_variables.scss
+++ b/yeti/_variables.scss
@@ -3,6 +3,7 @@ $bootstrap-sass-asset-helper: false !default;
 // Variables
 // --------------------------------------------------
 
+$web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700" !default;
 
 //== Colors
 //

--- a/yeti/bootswatch.less
+++ b/yeti/bootswatch.less
@@ -2,12 +2,7 @@
 // Bootswatch
 // -----------------------------------------------------
 
-@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700";
-
-.web-font(@path) {
-  @import url("@{path}");
-}
-.web-font(@web-font-path);
+@import (css) url("@{web-font-path}");
 
 // Navbar =====================================================================
 

--- a/yeti/variables.less
+++ b/yeti/variables.less
@@ -2,6 +2,7 @@
 // Variables
 // --------------------------------------------------
 
+@web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700";
 
 //== Colors
 //


### PR DESCRIPTION
Fix libsass compilation failing because imports inside mixins are not supported (fixes #514).

This is an alternate solution to PR #516 which requires less specific regular expressions for LESS conversion and moves the web path variable definition to the variables file.
