### PR TITLE
Bower: don't ignore global directory

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,6 @@
     "bower_components",
     "custom",
     "default",
-    "global",
     "help",
     "tests",
     "_config.yml",


### PR DESCRIPTION
I'm trying to compile SCSS version of the `spacelab` theme using Gulp, but the compilation fails, because of missing `build.scss` file.

As a workaround, I will include a copy of the file with my code, but I think that the `global` directory should be distributed along with the themes, since is strictly required for `less`/`sass` compiler.
