### PR TITLE
united: update Ubuntu orange

### DIFF
--- a/united/_variables.scss
+++ b/united/_variables.scss
@@ -15,7 +15,7 @@ $gray:                   #777 !default; // #555
 $gray-light:             #AEA79F !default;   // #999
 $gray-lighter:           lighten($gray-base, 93.5%) !default; // #eee
 
-$brand-primary:         #DD4814 !default;
+$brand-primary:         #E95420 !default;
 $brand-success:         #38B44A !default;
 $brand-info:            #772953 !default;
 $brand-warning:         #EFB73E !default;

--- a/united/variables.less
+++ b/united/variables.less
@@ -14,7 +14,7 @@
 @gray-light:             #AEA79F;   // #999
 @gray-lighter:           lighten(@gray-base, 93.5%); // #eee
 
-@brand-primary:         #DD4814;
+@brand-primary:         #E95420;
 @brand-success:         #38B44A;
 @brand-info:            #772953;
 @brand-warning:         #EFB73E;


### PR DESCRIPTION
Updating Ubuntu orange color per https://design.canonical.com/2016/04/ubuntu-orange-update/