### PR TITLE
Updating Help doc to include sass workflow

### DIFF
--- a/help/index.html
+++ b/help/index.html
@@ -117,8 +117,14 @@
               <li><p>Download the repository: <code>git clone https://github.com/thomaspark/bootswatch.git</code></p></li>
               <li><p>Install dependencies: <code>npm install</code></p></li>
               <li><p>Make sure that you have <code>grunt</code> available in the command line. You can install <code>grunt-cli</code> as described on the <a href="http://gruntjs.com/getting-started">Grunt Getting Started page</a>.</p></li>
-              <li><p>Modify <code>variables.less</code> and <code>bootswatch.less</code> in one of the theme directories, or create your own in <code>/custom</code>.</p></li>
-              <li><p>Type <code>grunt swatch:[theme]</code> to build the CSS for a theme, e.g., <code>grunt swatch:amelia</code> for Amelia. Or type <code>grunt swatch</code> to build them all at once. </p></li>
+              <li>
+                <p>Decide if you want to use <a href="http://lesscss.org/">Less</a> or <a href="http://sass-lang.com/">Sass</a> for customizing your theme.</p>
+                <ul>
+                  <li><p>For Less, modify <code>variables.less</code> and <code>bootswatch.less</code> in one of the theme directories, or create your own in <code>/custom</code>.</p></li>
+                  <li><p>For Sass, modify instead the <code>_variables.scss</code> and <code>_bootswatch.scss</code> files.</p></li>
+                </ul>
+              </li>
+              <li><p>Type <code>grunt swatch:[theme]</code> to build the Less based CSS for a theme, e.g., <code>grunt swatch:amelia</code> for Amelia. Or type <code>grunt swatch</code> to build them all at once. If you are using Sass, type <code>grunt swatch_scss:[theme]</code> instead.</p></li>
               <li><p>You can run <code>grunt</code> to start a server, watch for any changes to the LESS files, and automatically build a theme and reload it on change. Run <code>grunt server</code> for just the server, and <code>grunt watch</code> for just the watcher.</p></li>
             </ol>
             <p>Here are additional tips for <a href="http://www.smashingmagazine.com/2013/03/12/customizing-bootstrap/" target="_blank">customizing Bootstrap</a>.</p>


### PR DESCRIPTION
Hi, thanks for your work in this project!

While following the Help instructions for customizing a theme I got confused when my sass variables and styles weren't being included on the bundled styles. 

Then I noticed the dual less/sass files (I directly search for the sass file) and had to dive in the Gruntfile to figure out there was another task to process the scss files.

I thought to contribute a bit by updating the docs. Please let me know if you want any changes on they wording/order/whatever.