### PR TITLE
Fixed bg-inverse nav-link hover color

### DIFF
--- a/4-alpha/darkly/_bootswatch.scss
+++ b/4-alpha/darkly/_bootswatch.scss
@@ -10,9 +10,9 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 .bg-inverse {
   background-color: $brand-success !important;
 
-  &.navbar-dark .navbar-nav .nav-link:focus,
-  &.navbar-dark .navbar-nav .nav-link:hover {
-    color: $brand-primary;
+  &.navbar-inverse .navbar-nav .nav-link:focus,
+  &.navbar-inverse .navbar-nav .nav-link:hover {
+    color: $brand-primary !important;
   }
 }
 

--- a/4-alpha/flatly/_bootswatch.scss
+++ b/4-alpha/flatly/_bootswatch.scss
@@ -10,9 +10,9 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 .bg-inverse {
   background-color: $brand-success !important;
 
-  &.navbar-dark .navbar-nav .nav-link:focus,
-  &.navbar-dark .navbar-nav .nav-link:hover {
-    color: $brand-primary;
+  &.navbar-inverse .navbar-nav .nav-link:focus,
+  &.navbar-inverse .navbar-nav .nav-link:hover {
+    color: $brand-primary !important;
   }
 }
 


### PR DESCRIPTION
Fixed the nav-link hover color on Flatly and Darkly to use .navbar-inverse class instead of .navbar-dark class.