### PR TITLE
Port scss files to bootstrap v4-beta

### DIFF
--- a/cerulean/_bootswatch.scss
+++ b/cerulean/_bootswatch.scss
@@ -11,7 +11,7 @@ $text-shadow: 0 1px 0 rgba(0, 0, 0, 0.05) !default;
 // Navbar ======================================================================
 
 .bg-primary {
-  @include btn-shadow($brand-primary);
+  @include btn-shadow(theme-color("primary"));
 }
 
 .bg-inverse {

--- a/cerulean/_variables.scss
+++ b/cerulean/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #C71C22,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/cerulean/_variables.scss
+++ b/cerulean/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #2FA4E7 !default; // ChangedLineForBootstrap4
-$brand-success:             #73A839 !default; // ChangedLineForBootstrap4
-$brand-info:                #033C73 !default; // ChangedLineForBootstrap4
-$brand-warning:             #DD5600 !default; // ChangedLineForBootstrap4
-$brand-danger:              #C71C22 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default; // ChangedLineForBootstrap4
+$theme-colors: (
+  "primary": #2FA4E7,
+  "secondary": $gray,
+  "success": #73A839,
+  "info": #033C73,
+  "warning": #DD5600,
+  "danger": #C71C22,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -271,7 +255,7 @@ $headings-margin-bottom: ($spacer / 2) !default;
 $headings-font-family:   inherit !default;
 $headings-font-weight:   500 !default;
 $headings-line-height:   1.1 !default;
-$headings-color:         $brand-primary !default; // ChangedLineForBootstrap4
+$headings-color:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $display1-size: 6rem !default;
 $display2-size: 5.5rem !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           #ccc !default;
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +555,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            $gray-dark !default;
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.8) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           #fff !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          #fff !default; // ChangedLineForBootstrap4
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.8) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           #fff !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          #fff !default; // ChangedLineForBootstrap4
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/cosmo/_variables.scss
+++ b/cosmo/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #2780E3 !default; // ChangedLineForBootstrap4
-$brand-success:             #3FB618 !default; // ChangedLineForBootstrap4
-$brand-info:                #9954BB !default; // ChangedLineForBootstrap4
-$brand-warning:             #FF7518 !default; // ChangedLineForBootstrap4
-$brand-danger:              #FF0039 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #2780E3,
+  "secondary": $gray,
+  "success": #3FB618,
+  "info": #9954BB,
+  "warning": #FF7518,
+  "danger": #FF0039,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -183,15 +167,13 @@ $sizes: (
 
 $body-bg:       #fff !default;
 $body-color:    $gray-dark !default;
-$inverse-bg:    $gray-dark !default;
-$inverse-color: $gray-lighter !default;
 
 
 // Links
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +305,7 @@ $border-radius-lg:       0 !default; // ChangedLineForBootstrap4
 $border-radius-sm:       0 !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +346,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +358,19 @@ $btn-secondary-bg:               $gray-dark !default; // ChangedLineForBootstrap
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +411,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +439,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +461,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +496,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +504,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +528,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +594,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +651,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +749,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +805,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +835,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/cosmo/_variables.scss
+++ b/cosmo/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #FF0039,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/cyborg/_bootswatch.scss
+++ b/cyborg/_bootswatch.scss
@@ -64,7 +64,7 @@ legend,
     }
 
     &.active {
-      background-color: $brand-primary;
+      background-color: theme-color("primary");
     }
   }
 }

--- a/cyborg/_variables.scss
+++ b/cyborg/_variables.scss
@@ -111,13 +111,16 @@ $gray-lighter:              #888 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #ADAFAE !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #2A9FD6 !default; // ChangedLineForBootstrap4
-$brand-success:             #77B300 !default; // ChangedLineForBootstrap4
-$brand-info:                #9933CC !default; // ChangedLineForBootstrap4
-$brand-warning:             #FF8800 !default; // ChangedLineForBootstrap4
-$brand-danger:              #CC0000 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
-
+$theme-colors: (
+  "primary": #2A9FD6,
+  "secondary": $gray,
+  "success": #77B300,
+  "info": #9933CC,
+  "warning": #FF8800,
+  "danger": #CC0000,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 // Options
 //
@@ -139,33 +142,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +174,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +306,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +347,11 @@ $btn-padding-y:                  .5rem !default; // ChangedLineForBootstrap4
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +359,19 @@ $btn-secondary-bg:               lighten($gray, 10%) !default; // ChangedLineFor
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +412,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +440,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +462,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +497,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +505,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +529,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +554,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            #fff !default; // ChangedLineForBootstrap4
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +595,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           #fff !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          #fff !default; // ChangedLineForBootstrap4
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           #fff !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          #fff !default; // ChangedLineForBootstrap4
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -665,12 +648,12 @@ $pagination-border-width:              $border-width !default;
 $pagination-border-color:              transparent !default; // ChangedLineForBootstrap4
 
 $pagination-hover-color:               #fff !default; // ChangedLineForBootstrap4
-$pagination-hover-bg:                  $brand-primary !default; // ChangedLineForBootstrap4
+$pagination-hover-bg:                  theme-color("primary") !default; // ChangedLineForBootstrap4
 $pagination-hover-border:              $pagination-border-color !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $pagination-bg !default; // ChangedLineForBootstrap4
@@ -688,20 +671,20 @@ $jumbotron-bg:                   $gray-dark !default; // ChangedLineForBootstrap
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +750,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +806,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +836,7 @@ $progress-bg:                   $gray !default; // ChangedLineForBootstrap4
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/cyborg/_variables.scss
+++ b/cyborg/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #CC0000,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 // Options
 //

--- a/darkly/_bootswatch.scss
+++ b/darkly/_bootswatch.scss
@@ -8,11 +8,11 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 // Navbar ======================================================================
 
 .bg-inverse {
-  background-color: $brand-success !important;
+  background-color: theme-color("success") !important;
 
   &.navbar-inverse .navbar-nav .nav-link:focus,
   &.navbar-inverse .navbar-nav .nav-link:hover {
-    color: $brand-primary !important;
+    color: theme-color("primary") !important;
   }
 }
 
@@ -55,7 +55,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 }
 
 .thead-inverse th {
-  background-color: $brand-primary;
+  background-color: theme-color("primary");
 }
 
 

--- a/darkly/_variables.scss
+++ b/darkly/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #E74C3C,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/darkly/_variables.scss
+++ b/darkly/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #999 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #EBEBEB !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #375a7f !default; // ChangedLineForBootstrap4
-$brand-success:             #00bc8c !default; // ChangedLineForBootstrap4
-$brand-info:                #3498DB !default; // ChangedLineForBootstrap4
-$brand-warning:             #F39C12 !default; // ChangedLineForBootstrap4
-$brand-danger:              #E74C3C !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #375a7f,
+  "secondary": $gray,
+  "success": #00bc8c,
+  "info": #3498DB,
+  "warning": #F39C12,
+  "danger": #E74C3C,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-success !default; // ChangedLineForBootstrap4
+$link-color:            theme-color("success") !default; // ChangedLineForBootstrap4
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-light !default; // ChangedLineForBootstra
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-light !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +555,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            #fff !default; // ChangedLineForBootstrap4
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           $brand-success !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           theme-color("success") !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -660,12 +644,12 @@ $pagination-padding-y-lg:             .75rem !default;
 $pagination-line-height:              1.25 !default;
 
 $pagination-color:                     #fff !default; // ChangedLineForBootstrap4
-$pagination-bg:                        $brand-success !default; // ChangedLineForBootstrap4
+$pagination-bg:                        theme-color("success") !default; // ChangedLineForBootstrap4
 $pagination-border-width:              0 !default; // ChangedLineForBootstrap4
 $pagination-border-color:              transparent !default; // ChangedLineForBootstrap4
 
 $pagination-hover-color:               #fff !default; // ChangedLineForBootstrap4
-$pagination-hover-bg:                  lighten($brand-success, 10%) !default; // ChangedLineForBootstrap4
+$pagination-hover-bg:                  lighten(theme-color("success"), 10%) !default; // ChangedLineForBootstrap4
 $pagination-hover-border:              transparent !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
@@ -673,7 +657,7 @@ $pagination-active-bg:                 $pagination-hover-bg !default; // Changed
 $pagination-active-border:             transparent !default; // ChangedLineForBootstrap4
 
 $pagination-disabled-color:            #fff !default; // ChangedLineForBootstrap4
-$pagination-disabled-bg:               darken($brand-success, 15%) !default; // ChangedLineForBootstrap4
+$pagination-disabled-bg:               darken(theme-color("success"), 15%) !default; // ChangedLineForBootstrap4
 $pagination-disabled-border:           transparent !default; // ChangedLineForBootstrap4
 
 
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray !default; // ChangedLineForBootstrap4
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-light !default; // ChangedLineForBootstrap
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/flatly/_bootswatch.scss
+++ b/flatly/_bootswatch.scss
@@ -8,11 +8,11 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 // Navbar =======================================================================
 
 .bg-inverse {
-  background-color: $brand-success !important;
+  background-color: theme-color("success") !important;
 
   &.navbar-inverse .navbar-nav .nav-link:focus,
   &.navbar-inverse .navbar-nav .nav-link:hover {
-    color: $brand-primary !important;
+    color: theme-color("primary") !important;
   }
 }
 
@@ -47,7 +47,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
 }
 
 .thead-inverse th {
-  background-color: $brand-primary;
+  background-color: theme-color("primary");
 }
 
 
@@ -62,7 +62,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic"
   .nav-item.open .nav-link,
   .nav-item.open .nav-link:focus,
   .nav-item.open .nav-link:hover {
-    color: $brand-primary;
+    color: theme-color("primary");
   }
 }
 

--- a/flatly/_variables.scss
+++ b/flatly/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #E74C3C,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/flatly/_variables.scss
+++ b/flatly/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #b4bcc2 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #ecf0f1 !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #2C3E50 !default; // ChangedLineForBootstrap4
-$brand-success:             #18BC9C !default; // ChangedLineForBootstrap4
-$brand-info:                #3498DB !default; // ChangedLineForBootstrap4
-$brand-warning:             #F39C12 !default; // ChangedLineForBootstrap4
-$brand-danger:              #E74C3C !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #2C3E50,
+  "secondary": $gray,
+  "success": #18BC9C,
+  "info": #3498DB,
+  "warning": #F39C12,
+  "danger": #E74C3C,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-success !default; // ChangedLineForBootstrap4
+$link-color:            theme-color("success") !default; // ChangedLineForBootstrap4
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-light !default; // ChangedLineForBootstra
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +555,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            $gray !default; // ChangedLineForBootstrap4
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           $brand-success !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           theme-color("success") !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -660,12 +644,12 @@ $pagination-padding-y-lg:             .75rem !default;
 $pagination-line-height:              1.25 !default;
 
 $pagination-color:                     #fff !default; // ChangedLineForBootstrap4
-$pagination-bg:                        $brand-success !default; // ChangedLineForBootstrap4
+$pagination-bg:                        theme-color("success") !default; // ChangedLineForBootstrap4
 $pagination-border-width:              0 !default; // ChangedLineForBootstrap4
 $pagination-border-color:              transparent !default; // ChangedLineForBootstrap4
 
 $pagination-hover-color:               #fff !default; // ChangedLineForBootstrap4
-$pagination-hover-bg:                  darken($brand-success, 15%) !default; // ChangedLineForBootstrap4
+$pagination-hover-bg:                  darken(theme-color("success"), 15%) !default; // ChangedLineForBootstrap4
 $pagination-hover-border:              transparent !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
@@ -673,7 +657,7 @@ $pagination-active-bg:                 $pagination-hover-bg !default; // Changed
 $pagination-active-border:             transparent !default; // ChangedLineForBootstrap4
 
 $pagination-disabled-color:            $gray-lightest !default; // ChangedLineForBootstrap4
-$pagination-disabled-bg:               lighten($brand-success, 15%) !default; // ChangedLineForBootstrap4
+$pagination-disabled-bg:               lighten(theme-color("success"), 15%) !default; // ChangedLineForBootstrap4
 $pagination-disabled-border:           transparent !default; // ChangedLineForBootstrap4
 
 
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lightest !default; // ChangedLineForBoots
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/journal/_variables.scss
+++ b/journal/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #aaa !default; // ChangedLineForBootstrap4
 $gray-lightest:             #eee !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #EB6864 !default; // ChangedLineForBootstrap4
-$brand-success:             #22B24C !default; // ChangedLineForBootstrap4
-$brand-info:                #369 !default; // ChangedLineForBootstrap4
-$brand-warning:             #F5E625 !default; // ChangedLineForBootstrap4
-$brand-danger:              #F57A00 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #EB6864,
+  "secondary": $gray,
+  "success": #22B24C,
+  "info": #369,
+  "warning": #F5E625,
+  "danger": #F57A00,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lighter !default; // ChangedLineForBootst
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,.75) !default;
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,.75) !default;
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.7) !default;
 $navbar-light-hover-color:          rgba(0,0,0,1) !default; // ChangedLineForBootstrap4
@@ -665,12 +649,12 @@ $pagination-border-width:              $border-width !default;
 $pagination-border-color:              #ddd !default;
 
 $pagination-hover-color:               #fff !default; // ChangedLineForBootstrap4
-$pagination-hover-bg:                  $brand-primary !default; // ChangedLineForBootstrap4
-$pagination-hover-border:              $brand-primary !default; // ChangedLineForBootstrap4
+$pagination-hover-bg:                  theme-color("primary") !default; // ChangedLineForBootstrap4
+$pagination-hover-border:              theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lightest !default; // ChangedLineForBootst
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/journal/_variables.scss
+++ b/journal/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #F57A00,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/litera/_bootswatch.scss
+++ b/litera/_bootswatch.scss
@@ -25,7 +25,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700" !defau
 }
 
 .bg-inverse {
-  background-color: $brand-success !important;
+  background-color: theme-color("success") !important;
 }
 
 // Buttons =====================================================================

--- a/litera/_variables.scss
+++ b/litera/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #d9534f,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/litera/_variables.scss
+++ b/litera/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #ddd !default; // ChangedLineForBootstrap4
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #4582EC !default; // ChangedLineForBootstrap4
-$brand-success:             #02B875 !default; // ChangedLineForBootstrap4
-$brand-info:                #5bc0de !default;
-$brand-warning:             #f0ad4e !default;
-$brand-danger:              #d9534f !default;
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #4582EC,
+  "secondary": $gray,
+  "success": #02B875,
+  "info": #5bc0de,
+  "warning": #f0ad4e,
+  "danger": #d9534f,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-light !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           $gray-lighter !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.6) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.6) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.5) !default;
 $navbar-light-hover-color:          $body-color !default; // ChangedLineForBootstrap4
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lightest !default; // ChangedLineForBoots
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-lighter;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/lumen/_bootswatch.scss
+++ b/lumen/_bootswatch.scss
@@ -22,8 +22,8 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400
 }
 
 .bg-inverse {
-  background-color: $brand-primary !important;
-  border-color: darken($brand-primary, 5%) !important;
+  background-color: theme-color("primary") !important;
+  border-color: darken(theme-color("primary"), 5%) !important;
 }
 
 // Buttons =====================================================================
@@ -95,7 +95,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400
 }
 
 .thead-inverse th {
-  background-color: $brand-primary;
+  background-color: theme-color("primary");
 }
 
 // Forms =======================================================================

--- a/lumen/_variables.scss
+++ b/lumen/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #FF4136,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/lumen/_variables.scss
+++ b/lumen/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #999 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #f0f0f0 !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #158CBA !default; // ChangedLineForBootstrap4
-$brand-success:             #28B62C !default; // ChangedLineForBootstrap4
-$brand-info:                #75CAEB !default; // ChangedLineForBootstrap4
-$brand-warning:             #FF851B !default; // ChangedLineForBootstrap4
-$brand-danger:              #FF4136 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #158CBA,
+  "secondary": $gray,
+  "success": #28B62C,
+  "info": #75CAEB,
+  "warning": #FF851B,
+  "danger": #FF4136,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             darken($btn-primary-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           darken($btn-secondary-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                darken($btn-info-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             darken($btn-success-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             darken($btn-warning-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              darken($btn-danger-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,.75) !default;
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,.75) !default;
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $pagination-bg !default; // ChangedLineFo
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             darken($brand-primary, 5%) !default; // ChangedLineForBootstrap4
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             darken(theme-color("primary"), 5%) !default; // ChangedLineForBootstrap4
 
 $pagination-disabled-color:            $gray-lighter !default; // ChangedLineForBootstrap4
 $pagination-disabled-bg:               $pagination-bg !default; // ChangedLineForBootstrap4
@@ -688,20 +672,20 @@ $jumbotron-bg:                   #fafafa !default; // ChangedLineForBootstrap4
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lightest !default; // ChangedLineForBootst
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/lux/_variables.scss
+++ b/lux/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #d9534f,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/lux/_variables.scss
+++ b/lux/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             $gray-dark !default; // ChangedLineForBootstrap4
-$brand-success:             #4BBF73 !default; // ChangedLineForBootstrap4
-$brand-info:                #1F9BCF !default; // ChangedLineForBootstrap4
-$brand-warning:             #f0ad4e !default;
-$brand-danger:              #d9534f !default;
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": $gray-dark,
+  "secondary": $gray,
+  "success": #4BBF73,
+  "info": #1F9BCF,
+  "warning": #f0ad4e,
+  "danger": #d9534f,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       0 !default; // ChangedLineForBootstrap4
 $border-radius-sm:       0 !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  0.75rem !default; // ChangedLineForBootstrap4
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.3) !default; // ChangedLineForBootstrap4
 $navbar-light-hover-color:          $gray-dark !default; // ChangedLineForBootstrap4
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              $pagination-border-color !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/materia/_bootswatch.scss
+++ b/materia/_bootswatch.scss
@@ -217,7 +217,7 @@ a {
 }
 
 .thead-inverse th {
-  background-color: $brand-primary;
+  background-color: theme-color("primary");
 }
 
 // Forms =======================================================================
@@ -259,7 +259,7 @@ input[type=number],
   transition: all 0.2s;
 
   &:focus {
-    box-shadow: inset 0 -2px 0 $brand-primary;
+    box-shadow: inset 0 -2px 0 theme-color("primary");
   }
 
   &[disabled],
@@ -319,7 +319,7 @@ select.form-control {
   }
 
   &:focus {
-    box-shadow: inset 0 -2px 0 $brand-primary;
+    box-shadow: inset 0 -2px 0 theme-color("primary");
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAaCAMAAACelLz8AAAAJ1BMVEUhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISF8S9ewAAAADHRSTlMAAgMJC0uWpKa6wMxMdjkoAAAANUlEQVR4AeXJyQEAERAAsNl7Hf3X6xt0QL6JpZWq30pdvdadme+0PMdzvHm8YThHcT1H7K0BtOMDniZhWOgAAAAASUVORK5CYII=);
   }
 
@@ -371,7 +371,7 @@ input[type="radio"],
     position: absolute;
     left: 0;
     top: 2px;
-    background-color: $brand-primary;
+    background-color: theme-color("primary");
     transform: scale(0);
   }
 
@@ -390,7 +390,7 @@ input[type="radio"],
   }
 
   &:checked:after {
-    border-color: $brand-primary;
+    border-color: theme-color("primary");
   }
 
   &:disabled:after,
@@ -413,7 +413,7 @@ input[type="checkbox"],
   }
 
   &:focus:after {
-    border-color: $brand-primary;
+    border-color: theme-color("primary");
   }
 
   &:after {
@@ -442,8 +442,8 @@ input[type="checkbox"],
   }
 
   &:checked:after {
-    background-color: $brand-primary;
-    border-color: $brand-primary;
+    background-color: theme-color("primary");
+    border-color: theme-color("primary");
   }
 
   &:disabled:after {
@@ -465,7 +465,7 @@ input[type="checkbox"],
   input:not([type=checkbox]):focus,
   .form-control:focus {
     border-bottom: none;
-    box-shadow: inset 0 -2px 0 $brand-warning;
+    box-shadow: inset 0 -2px 0 theme-color("warning");
   }
 }
 
@@ -478,7 +478,7 @@ input[type="checkbox"],
   input:not([type=checkbox]):focus,
   .form-control:focus {
     border-bottom: none;
-    box-shadow: inset 0 -2px 0 $brand-danger;
+    box-shadow: inset 0 -2px 0 theme-color("danger");
   }
 }
 
@@ -491,7 +491,7 @@ input[type="checkbox"],
   input:not([type=checkbox]):focus,
   .form-control:focus {
     border-bottom: none;
-    box-shadow: inset 0 -2px 0 $brand-success;
+    box-shadow: inset 0 -2px 0 theme-color("success");
   }
 }
 
@@ -529,20 +529,20 @@ input[type="checkbox"],
 
     &:hover {
       background-color: transparent;
-      box-shadow: inset 0 -2px 0 $brand-primary;
-      color: $brand-primary;
+      box-shadow: inset 0 -2px 0 theme-color("primary");
+      color: theme-color("primary");
     }
   }
 
   .nav-link.active,
   .nav-link.active:focus {
     border: none;
-    box-shadow: inset 0 -2px 0 $brand-primary;
-    color: $brand-primary;
+    box-shadow: inset 0 -2px 0 theme-color("primary");
+    color: theme-color("primary");
 
     &:hover {
       border: none;
-      color: $brand-primary;
+      color: theme-color("primary");
     }
   }
 

--- a/materia/_variables.scss
+++ b/materia/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #e51c23,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/materia/_variables.scss
+++ b/materia/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #bbb !default; // ChangedLineForBootstrap4
 $gray-lightest:             #eee !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #2196F3 !default; // ChangedLineForBootstrap4
-$brand-success:             #4CAF50 !default; // ChangedLineForBootstrap4
-$brand-info:                #9C27B0 !default; // ChangedLineForBootstrap4
-$brand-warning:             #ff9800 !default; // ChangedLineForBootstrap4
-$brand-danger:              #e51c23 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #2196F3,
+  "secondary": $gray,
+  "success": #4CAF50,
+  "info": #9C27B0,
+  "warning": #ff9800,
+  "danger": #e51c23,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  1rem !default; // ChangedLineForBootstrap4
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           #ccc !default;
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           transparent !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.6) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.6) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-lighter;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,24 +807,24 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
 
-$alert-success-bg:            $brand-success !default; // ChangedLineForBootstrap4
+$alert-success-bg:            theme-color("success") !default; // ChangedLineForBootstrap4
 $alert-success-text:          #fff !default; // ChangedLineForBootstrap4
 $alert-success-border:        $state-success-border !default;
 
-$alert-info-bg:               $brand-info !default; // ChangedLineForBootstrap4
+$alert-info-bg:               theme-color("info") !default; // ChangedLineForBootstrap4
 $alert-info-text:             #fff !default; // ChangedLineForBootstrap4
 $alert-info-border:           $state-info-border !default;
 
-$alert-warning-bg:            $brand-warning !default; // ChangedLineForBootstrap4
+$alert-warning-bg:            theme-color("warning") !default; // ChangedLineForBootstrap4
 $alert-warning-text:          #fff !default; // ChangedLineForBootstrap4
 $alert-warning-border:        $state-warning-border !default;
 
-$alert-danger-bg:             $brand-danger !default; // ChangedLineForBootstrap4
+$alert-danger-bg:             theme-color("danger") !default; // ChangedLineForBootstrap4
 $alert-danger-text:           #fff !default; // ChangedLineForBootstrap4
 $alert-danger-border:         $state-danger-border !default;
 
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/minty/_bootswatch.scss
+++ b/minty/_bootswatch.scss
@@ -26,7 +26,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Montserrat" !default;
 // Tables ======================================================================
 
 .thead-inverse th {
-  background-color: $brand-primary;
+  background-color: theme-color("primary");
   font-family: $headings-font-family;
 }
 
@@ -51,7 +51,7 @@ legend {
 
 .breadcrumb {
   a {
-    color: $navbar-inverse-color;
+    color: $navbar-dark-color;
   }
 
   a:hover {

--- a/minty/_variables.scss
+++ b/minty/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #eceeef !default;
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #78C2AD !default; // ChangedLineForBootstrap4
-$brand-success:             #56CC9D !default; // ChangedLineForBootstrap4
-$brand-info:                #6CC3D5 !default; // ChangedLineForBootstrap4
-$brand-warning:             #FFCE67 !default; // ChangedLineForBootstrap4
-$brand-danger:              #FF7851 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #78C2AD,
+  "secondary": $gray,
+  "success": #56CC9D,
+  "info": #6CC3D5,
+  "warning": #6CC3D5,
+  "danger": #6CC3D5,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .6rem !default; // ChangedLineForBootstrap4
 $border-radius-sm:       .3rem !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               #F3969A !default; // ChangedLineForBootstrap4
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.6) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default;
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.6) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default;
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.3) !default; // ChangedLineForBootstrap4
 $navbar-light-hover-color:          $headings-color !default; // ChangedLineForBootstrap4
@@ -660,7 +644,7 @@ $pagination-padding-y-lg:             .75rem !default;
 $pagination-line-height:              1.25 !default;
 
 $pagination-color:                     #fff !default; // ChangedLineForBootstrap4
-$pagination-bg:                        $brand-primary !default; // ChangedLineForBootstrap4
+$pagination-bg:                        theme-color("primary") !default; // ChangedLineForBootstrap4
 $pagination-border-width:              $border-width !default;
 $pagination-border-color:              $pagination-bg !default; // ChangedLineForBootstrap4
 
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lightest !default; // ChangedLineForBoots
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           $state-success-bg !default; // ChangedLineForBootstrap4
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              $state-info-bg !default; // ChangedLineForBootstrap4
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           $state-warning-bg !default; // ChangedLineForBootstrap4
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            $state-danger-bg !default; // ChangedLineForBootstrap4
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group
@@ -908,7 +892,7 @@ $breadcrumb-padding-y:          .75rem !default;
 $breadcrumb-padding-x:          1rem !default;
 $breadcrumb-item-padding:       .5rem !default;
 
-$breadcrumb-bg:                 $brand-primary !default; // ChangedLineForBootstrap4
+$breadcrumb-bg:                 theme-color("primary") !default; // ChangedLineForBootstrap4
 $breadcrumb-divider-color:      #fff !default; // ChangedLineForBootstrap4
 $breadcrumb-active-color:       $breadcrumb-divider-color !default; // ChangedLineForBootstrap4
 $breadcrumb-divider:            "/" !default;

--- a/minty/_variables.scss
+++ b/minty/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #6CC3D5,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/pulse/_bootswatch.scss
+++ b/pulse/_bootswatch.scss
@@ -20,7 +20,7 @@
   }
 
   &-primary:focus {
-    box-shadow: 0 0 5px lighten($brand-primary, 10%);
+    box-shadow: 0 0 5px lighten(theme-color("primary"), 10%);
   }
 
   &-secondary:focus {
@@ -28,19 +28,19 @@
   }
 
   &-success:focus {
-    box-shadow: 0 0 5px lighten($brand-success, 10%);
+    box-shadow: 0 0 5px lighten(theme-color("success"), 10%);
   }
 
   &-info:focus {
-    box-shadow: 0 0 5px lighten($brand-info, 10%);
+    box-shadow: 0 0 5px lighten(theme-color("info"), 10%);
   }
 
   &-warning:focus {
-    box-shadow: 0 0 5px lighten($brand-warning, 10%);
+    box-shadow: 0 0 5px lighten(theme-color("warning"), 10%);
   }
 
   &-danger:focus {
-    box-shadow: 0 0 5px lighten($brand-danger, 10%);
+    box-shadow: 0 0 5px lighten(theme-color("danger"), 10%);
   }
 
   &.disabled:focus {
@@ -76,7 +76,7 @@
   .nav-link.active,
   .nav-link.active:hover,
   .nav-link.active:focus {
-    border-bottom: 1px solid $brand-primary;
+    border-bottom: 1px solid theme-color("primary");
   }
 
   .nav-item + .nav-item {

--- a/pulse/_variables.scss
+++ b/pulse/_variables.scss
@@ -111,13 +111,16 @@ $gray-lighter:              #EDEDED !default; // ChangedLineForBootstrap4
 $gray-lightest:             #F9F8FC !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #593196 !default;
-$brand-success:             #13B955 !default; // ChangedLineForBootstrap4
-$brand-info:                #009CDC !default; // ChangedLineForBootstrap4
-$brand-warning:             #EFA31D !default; // ChangedLineForBootstrap4
-$brand-danger:              #FC3939 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
-
+$theme-colors: (
+  "primary": #593196,
+  "secondary": $gray,
+  "success": #13B955,
+  "info": #009CDC,
+  "warning": #EFA31D,
+  "danger": #FC3939,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 // Options
 //
@@ -139,33 +142,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +174,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      $link-color !default; // ChangedLineForBootstrap4
 $link-hover-decoration: underline !default;
@@ -323,7 +306,7 @@ $border-radius-lg:       0 !default; // ChangedLineForBootstrap4
 $border-radius-sm:       0 !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +347,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +359,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           #ccc !default;
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +412,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             $brand-primary !default; // ChangedLineForBootstrap4
+$input-border-focus:             theme-color("primary") !default; // ChangedLineForBootstrap4
 $input-box-shadow-focus:         $input-box-shadow, 0 0 8px rgba(102,175,233,.6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +440,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +462,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +497,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +505,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +529,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +554,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            $gray !default; // ChangedLineForBootstrap4
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +595,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,.9) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,.9) !default; // ChangedLineForBootstrap4
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,.9) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,.9) !default; // ChangedLineForBootstrap4
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.4) !default; // ChangedLineForBootstrap4
 $navbar-light-hover-color:          rgba(0,0,0,.7) !default; // ChangedLineForBootstrap4
@@ -637,7 +620,7 @@ $nav-disabled-link-color:       $gray-light !default;
 $nav-tabs-border-color:                       $gray-lighter !default; // ChangedLineForBootstrap4
 $nav-tabs-border-width:                       $border-width !default;
 $nav-tabs-border-radius:                      $border-radius !default;
-$nav-tabs-link-hover-border-color:            $brand-primary !default; // ChangedLineForBootstrap4
+$nav-tabs-link-hover-border-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
 $nav-tabs-active-link-hover-color:            $gray !default;
 $nav-tabs-active-link-hover-bg:               $body-bg !default;
 $nav-tabs-active-link-hover-border-color:     $nav-tabs-link-hover-border-color !default; // ChangedLineForBootstrap4
@@ -669,8 +652,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +750,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            #A991D4;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +806,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +836,7 @@ $progress-bg:                   $gray-lighter !default; // ChangedLineForBootstr
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            #A991D4 !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/pulse/_variables.scss
+++ b/pulse/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #FC3939,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 // Options
 //

--- a/sandstone/_variables.scss
+++ b/sandstone/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #d9534f,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/sandstone/_variables.scss
+++ b/sandstone/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #DFD7CA !default; // ChangedLineForBootstrap4
 $gray-lightest:             #F8F5F0 !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #325D88 !default; // ChangedLineForBootstrap4
-$brand-success:             #93C54B !default; // ChangedLineForBootstrap4
-$brand-info:                #29ABE0 !default; // ChangedLineForBootstrap4
-$brand-warning:             #F47C3C !default; // ChangedLineForBootstrap4
-$brand-danger:              #d9534f !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #325D88,
+  "secondary": $gray,
+  "success": #93C54B,
+  "info": #29ABE0,
+  "warning": #F47C3C,
+  "danger": #d9534f,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-success !default; // ChangedLineForBootstrap4
+$link-color:            theme-color("success") !default; // ChangedLineForBootstrap4
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-dark !default; // ChangedLineForBootstrap
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.5) !default;
 $navbar-light-hover-color:          rgba(0,0,0,1) !default; // ChangedLineForBootstrap4
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lightest !default; // ChangedLineForBoots
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           transparent !default; // ChangedLineForBootstrap4
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              transparent !default; // ChangedLineForBootstrap4
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           transparent !default; // ChangedLineForBootstrap4
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            transparent !default; // ChangedLineForBootstrap4
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   $gray-lighter !default; // ChangedLineForBootstrap4
 $progress-border-radius:        10px !default; // ChangedLineForBootstrap4
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/simplex/_bootswatch.scss
+++ b/simplex/_bootswatch.scss
@@ -33,8 +33,8 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700" !def
 }
 
 .bg-inverse {
-  background-color: $brand-primary !important;
-  border-color: darken($brand-primary, 6.5%) !important;
+  background-color: theme-color("primary") !important;
+  border-color: darken(theme-color("primary"), 6.5%) !important;
 }
 
 // Buttons =====================================================================

--- a/simplex/_variables.scss
+++ b/simplex/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #bbb !default; // ChangedLineForBootstrap4
 $gray-lightest:             #ddd !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #D9230F !default; // ChangedLineForBootstrap4
-$brand-success:             #469408 !default; // ChangedLineForBootstrap4
-$brand-info:                #029ACF !default; // ChangedLineForBootstrap4
-$brand-warning:             #9B479F !default; // ChangedLineForBootstrap4
-$brand-danger:              #D9831F !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #D9230F,
+  "secondary": $gray,
+  "success": #469408,
+  "info": #029ACF,
+  "warning": #9B479F,
+  "danger": #D9831F,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           #ccc !default;
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -571,7 +555,7 @@ $dropdown-box-shadow:            0 .5rem 1rem rgba($black,.175) !default;
 
 $dropdown-link-color:            $gray-dark !default;
 $dropdown-link-hover-color:      #fff !default; // ChangedLineForBootstrap4
-$dropdown-link-hover-bg:         $brand-primary !default; // ChangedLineForBootstrap4
+$dropdown-link-hover-bg:         theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $dropdown-link-active-color:     $component-active-color !default;
 $dropdown-link-active-bg:        $component-active-bg !default;
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -665,12 +649,12 @@ $pagination-border-width:              $border-width !default;
 $pagination-border-color:              darken(#fff, 6.5%) !default; // ChangedLineForBootstrap4
 
 $pagination-hover-color:               #fff !default; // ChangedLineForBootstrap4
-$pagination-hover-bg:                  $brand-primary !default; // ChangedLineForBootstrap4
-$pagination-hover-border:              $brand-primary !default; // ChangedLineForBootstrap4
+$pagination-hover-bg:                  theme-color("primary") !default; // ChangedLineForBootstrap4
+$pagination-hover-border:              theme-color("primary") !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-lighter !default; // ChangedLineForBootstrap4
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/simplex/_variables.scss
+++ b/simplex/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #D9831F,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/sketchy/_bootswatch.scss
+++ b/sketchy/_bootswatch.scss
@@ -72,7 +72,7 @@ table {
   .table-success,
   .table-success:hover {
     td, th {
-      background-color: $brand-success;
+      background-color: theme-color("success");
       color: $white;
     }
   }
@@ -80,7 +80,7 @@ table {
   .table-info,
   .table-info:hover {
     td, th {
-      background-color: $brand-info;
+      background-color: theme-color("info");
       color: $white;
     }
   }
@@ -88,7 +88,7 @@ table {
   .table-warning,
   .table-warning:hover {
     td, th {
-      background-color: $brand-warning;
+      background-color: theme-color("warning");
       color: $white;
     }
   }
@@ -96,7 +96,7 @@ table {
   .table-danger,
   .table-danger:hover {
     td, th {
-      background-color: $brand-danger;
+      background-color: theme-color("danger");
       color: $white;
     }
   }

--- a/sketchy/_variables.scss
+++ b/sketchy/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": $red,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/sketchy/_variables.scss
+++ b/sketchy/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #ccc !default; // ChangedLineForBootstrap4
 $gray-lightest:             #f7f7f9 !default;
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             $gray-dark !default; // ChangedLineForBootstrap4
-$brand-success:             $green !default;
-$brand-info:                $teal !default;
-$brand-warning:             $orange !default;
-$brand-danger:              $red !default;
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": $gray-dark,
+  "secondary": $gray,
+  "success": $green,
+  "info": $teal,
+  "warning": $orange,
+  "danger": $red,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 2px !default; // ChangedLineForBootstrap4
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       underline !default; // ChangedLineForBootstrap4
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       555px 25px 15px 25px/25px 5px 35px 555px !default; // C
 $border-radius-sm:       255px 25px 225px 25px/25px 225px 25px 255px !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            $gray-dark !default;
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $white !default;
 $btn-secondary-border:           $gray-dark !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 $white !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           $white !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          $white !default; // ChangedLineForBootstrap4
-$navbar-inverse-disabled-color:        rgba($white,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        $white !default; // ChangedLineForBootstrap4
+$navbar-dark-color:                 $white !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           $white !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          $white !default; // ChangedLineForBootstrap4
+$navbar-dark-disabled-color:        rgba($white,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        $white !default; // ChangedLineForBootstrap4
 
 $navbar-light-color:                $gray-dark !default; // ChangedLineForBootstrap4
 $navbar-light-hover-color:          $gray-dark !default; // ChangedLineForBootstrap4
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-dark !default; // ChangedLineForBoo
 $pagination-hover-border:              $gray-dark !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-lighter !default; // ChangedLineForBootstrap4
 $pagination-disabled-bg:               $white !default;
@@ -687,20 +671,20 @@ $jumbotron-bg:                   transparent !default; // ChangedLineForBootstra
 //
 // Define colors for form feedback states and, by default, alerts.
 
-$state-success-text:             $brand-success !default; // ChangedLineForBootstrap4
+$state-success-text:             theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-bg:               #dff0d8 !default;
 $state-success-border:           $state-success-text !default; // ChangedLineForBootstrap4
 
-$state-info-text:                $brand-info !default; // ChangedLineForBootstrap4
+$state-info-text:                theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-bg:                  #d9edf7 !default;
 $state-info-border:              $state-info-text !default; // ChangedLineForBootstrap4
 
-$state-warning-text:             $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-text:             theme-color("warning") !default; // ChangedLineForBootstrap4
 $state-warning-bg:               #fcf8e3 !default;
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           $state-warning-text !default; // ChangedLineForBootstrap4
 
-$state-danger-text:              $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-text:              theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-bg:                #f2dede !default;
 $state-danger-border:            $state-danger-text !default; // ChangedLineForBootstrap4
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;

--- a/slate/_bootswatch.scss
+++ b/slate/_bootswatch.scss
@@ -77,7 +77,7 @@
 }
 
 .bg-inverse {
-  background-color: $brand-primary !important;
+  background-color: theme-color("primary") !important;
 }
 
 // Buttons =====================================================================

--- a/slate/_variables.scss
+++ b/slate/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #ee5f5b,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/slate/_variables.scss
+++ b/slate/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #7A8288 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #999 !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             $gray-light !default; // ChangedLineForBootstrap4
-$brand-success:             #62c462 !default; // ChangedLineForBootstrap4
-$brand-info:                #5bc0de !default; // ChangedLineForBootstrap4
-$brand-warning:             #f89406 !default; // ChangedLineForBootstrap4
-$brand-danger:              #ee5f5b !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": $gray-light,
+  "secondary": $gray,
+  "success": #62c462,
+  "info": #5bc0de,
+  "warning": #f89406,
+  "danger": #ee5f5b,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .75rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lighter !default; // ChangedLineForBootst
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -688,20 +672,20 @@ $jumbotron-bg:                   darken($gray-dark, 5%) !default; // ChangedLine
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-lighter;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   darken($gray-dark, 5%) !default; // ChangedLineF
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $gray-lighter !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/solar/_bootswatch.scss
+++ b/solar/_bootswatch.scss
@@ -12,7 +12,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro" !defau
 }
 
 .bg-inverse {
-  background-color: $brand-primary !important;
+  background-color: theme-color("primary") !important;
 }
 
 // Buttons =====================================================================

--- a/solar/_variables.scss
+++ b/solar/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #EEE8D5 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #FDF6E3 !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #B58900 !default; // ChangedLineForBootstrap4
-$brand-success:             #2AA198 !default; // ChangedLineForBootstrap4
-$brand-info:                #268BD2 !default; // ChangedLineForBootstrap4
-$brand-warning:             #CB4B16 !default; // ChangedLineForBootstrap4
-$brand-danger:              #D33682 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #B58900,
+  "secondary": $gray,
+  "success": #2AA198,
+  "info": #268BD2,
+  "warning": #CB4B16,
+  "danger": #D33682,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 2px !default; // ChangedLineForBootstrap4
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-success !default; // ChangedLineForBootstrap4
+$link-color:            theme-color("success") !default; // ChangedLineForBootstrap4
 $link-decoration:       none !default;
 $link-hover-color:      $link-color !default; // ChangedLineForBootstrap4
 $link-hover-decoration: underline !default;
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               #586E75 !default; // ChangedLineForBootstrap4
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.5) !default;
-$navbar-inverse-hover-color:           rgba(255,255,255,.75) !default;
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.5) !default;
+$navbar-dark-hover-color:           rgba(255,255,255,.75) !default;
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -638,7 +622,7 @@ $nav-tabs-border-color:                       $gray !default; // ChangedLineForB
 $nav-tabs-border-width:                       $border-width !default;
 $nav-tabs-border-radius:                      $border-radius !default;
 $nav-tabs-link-hover-border-color:            $nav-tabs-border-color !default; // ChangedLineForBootstrap4
-$nav-tabs-active-link-hover-color:            $navbar-inverse-hover-color !default; // ChangedLineForBootstrap4
+$nav-tabs-active-link-hover-color:            $navbar-dark-hover-color !default; // ChangedLineForBootstrap4
 $nav-tabs-active-link-hover-bg:               $body-bg !default;
 $nav-tabs-active-link-hover-border-color:     $nav-tabs-border-color !default; // ChangedLineForBootstrap4
 $nav-tabs-justified-link-border-color:        $nav-tabs-border-color !default; // ChangedLineForBootstrap4
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $component-active-bg !default; // ChangedLineFo
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   $component-active-bg !default; // ChangedLineForBootstrap4
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/solar/_variables.scss
+++ b/solar/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #D33682,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/spacelab/_bootswatch.scss
+++ b/spacelab/_bootswatch.scss
@@ -39,7 +39,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700
 }
 
 .bg-inverse {
-  @include btn-shadow($brand-primary);
+  @include btn-shadow(theme-color("primary"));
 }
 
 // Buttons =====================================================================

--- a/spacelab/_variables.scss
+++ b/spacelab/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #999 !default; // ChangedLineForBootstrap4
 $gray-lightest:             #eee !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #446E9B !default; // ChangedLineForBootstrap4
-$brand-success:             #3CB521 !default; // ChangedLineForBootstrap4
-$brand-info:                #3399F3 !default; // ChangedLineForBootstrap4
-$brand-warning:             #D47500 !default; // ChangedLineForBootstrap4
-$brand-danger:              #CD0200 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #446E9B,
+  "secondary": $gray,
+  "success": #3CB521,
+  "info": #3399F3,
+  "warning": #D47500,
+  "danger": #CD0200,
+  "light": $gray-light,
+  "dark": $gray-dark
+) !default;
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-info !default; // ChangedLineForBootstrap4
+$link-color:            theme-color("info") !default; // ChangedLineForBootstrap4
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lighter !default; // ChangedLineForBootst
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,15 +596,15 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default;
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default;
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba(0,0,0,.4) !default; // ChangedLineForBootstrap4
-$navbar-light-hover-color:          $brand-info !default; // ChangedLineForBootstrap4
+$navbar-light-hover-color:          theme-color("info") !default; // ChangedLineForBootstrap4
 $navbar-light-active-color:         $navbar-light-color !default; // ChangedLineForBootstrap4
 $navbar-light-disabled-color:       rgba(0,0,0,.3) !default;
 $navbar-light-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-light-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -853,7 +837,7 @@ $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
 $progress-bar-color:            $white !default;
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/superhero/_bootswatch.scss
+++ b/superhero/_bootswatch.scss
@@ -12,7 +12,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700" !defa
 }
 
 .bg-inverse {
-  background-color: $brand-primary !important;
+  background-color: theme-color("primary") !important;
 }
 
 .navbar {

--- a/superhero/_variables.scss
+++ b/superhero/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #d9534f,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/superhero/_variables.scss
+++ b/superhero/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #4E5D6C !default; // ChangedLineForBootstrap4
 $gray-lightest:             #EBEBEB !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #DF691A !default; // ChangedLineForBootstrap4
-$brand-success:             #5cb85c !default; // ChangedLineForBootstrap4
-$brand-info:                #5bc0de !default; // ChangedLineForBootstrap4
-$brand-warning:             #f0ad4e !default; // ChangedLineForBootstrap4
-$brand-danger:              #d9534f !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #DF691A,
+  "secondary": $gray,
+  "success": #5cb85c,
+  "info": #5bc0de,
+  "warning": #f0ad4e,
+  "danger": #d9534f,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       0 !default; // ChangedLineForBootstrap4
 $border-radius-sm:       0 !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lighter !default; // ChangedLineForBootst
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lighter !default;
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $nav-disabled-link-color !default; // Cha
 $pagination-hover-border:              $pagination-border-color !default; // ChangedLineForBootstrap4
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $nav-disabled-link-color !default; // ChangedLineForBootstrap4
 $pagination-disabled-bg:               $pagination-bg !default; // ChangedLineForBootstrap4
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lighter !default;
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $nav-disabled-link-color;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   $gray-lighter !default; // ChangedLineForBootstrap4
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/united/_bootswatch.scss
+++ b/united/_bootswatch.scss
@@ -8,7 +8,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700" !defaul
 // Navbar ======================================================================
 
 .bg-inverse {
-  background-color: $brand-info !important;
+  background-color: theme-color("info") !important;
 }
 
 // Buttons =====================================================================
@@ -18,7 +18,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700" !defaul
 // Tables ======================================================================
 
 .thead-inverse th {
-  background-color: $brand-info;
+  background-color: theme-color("info");
 }
 
 // Forms =======================================================================

--- a/united/_variables.scss
+++ b/united/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #AEA79F !default; // ChangedLineForBootstrap4
 $gray-lightest:             #eee !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #E95420 !default; // ChangedLineForBootstrap4
-$brand-success:             #38B44A !default; // ChangedLineForBootstrap4
-$brand-info:                #772953 !default; // ChangedLineForBootstrap4
-$brand-warning:             #EFB73E !default; // ChangedLineForBootstrap4
-$brand-danger:              #DF382C !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #E95420,
+  "secondary": $gray,
+  "success": #38B44A,
+  "info": #772953,
+  "warning": #EFB73E,
+  "danger": #DF382C,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       .3rem !default;
 $border-radius-sm:       .2rem !default;
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                $font-weight-normal !default;
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             $btn-primary-bg !default;
 
 $btn-secondary-color:            #fff !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lighter !default; // ChangedLineForBootst
 $btn-secondary-border:           $btn-secondary-bg !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                $btn-info-bg !default;
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             $btn-success-bg !default;
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             $btn-warning-bg !default;
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              $btn-danger-bg !default;
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.75) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,8 +653,8 @@ $pagination-hover-bg:                  $gray-lighter !default;
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
-$pagination-active-border:             $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
+$pagination-active-border:             theme-color("primary") !default;
 
 $pagination-disabled-color:            $gray-light !default;
 $pagination-disabled-bg:               $white !default;
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   $gray-lighter !default;
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/united/_variables.scss
+++ b/united/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #DF382C,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options

--- a/yeti/_bootswatch.scss
+++ b/yeti/_bootswatch.scss
@@ -15,17 +15,17 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400
 .bg-primary {
 
   .dropdown-menu {
-    background-color: $brand-primary;
+    background-color: theme-color("primary");
 
     .dropdown-item,
     .dropdown-item:focus {
-      color: $navbar-inverse-color;
+      color: $navbar-dark-color;
     }
 
     .dropdown-item.active,
     .dropdown-item:hover,
     .dropdown-item:focus {
-      background-color: darken($brand-primary, 5%);
+      background-color: darken(theme-color("primary"), 5%);
       color: #fff;
     }
   }
@@ -39,7 +39,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400
 
     .dropdown-item,
     .dropdown-item:focus {
-      color: $navbar-inverse-color;
+      color: $navbar-dark-color;
     }
 
     .dropdown-item.active,

--- a/yeti/_variables.scss
+++ b/yeti/_variables.scss
@@ -111,12 +111,16 @@ $gray-lighter:              #ccc !default; // ChangedLineForBootstrap4
 $gray-lightest:             #eee !default; // ChangedLineForBootstrap4
 
 // Reassign color vars to semantic color scheme
-$brand-primary:             #008cba !default; // ChangedLineForBootstrap4
-$brand-success:             #43ac6a !default; // ChangedLineForBootstrap4
-$brand-info:                #5bc0de !default; // ChangedLineForBootstrap4
-$brand-warning:             #E99002 !default; // ChangedLineForBootstrap4
-$brand-danger:              #F04124 !default; // ChangedLineForBootstrap4
-$brand-inverse:             $gray-dark !default;
+$theme-colors: (
+  "primary": #008cba,
+  "secondary": $gray,
+  "success": #43ac6a,
+  "info": #5bc0de,
+  "warning": #E99002,
+  "danger": #F04124,
+  "light": $gray-light,
+  "dark": $gray-dark
+);
 
 
 // Options
@@ -139,33 +143,13 @@ $enable-print-styles:       true !default;
 // You can add more entries to the $spacers map, should you need more variation.
 
 $spacer:   1rem !default;
-$spacer-x: $spacer !default;
-$spacer-y: $spacer !default;
 $spacers: (
-  0: (
-    x: 0,
-    y: 0
-  ),
-  1: (
-    x: ($spacer-x * .25),
-    y: ($spacer-y * .25)
-  ),
-  2: (
-    x: ($spacer-x * .5),
-    y: ($spacer-y * .5)
-  ),
-  3: (
-    x: $spacer-x,
-    y: $spacer-y
-  ),
-  4: (
-    x: ($spacer-x * 1.5),
-    y: ($spacer-y * 1.5)
-  ),
-  5: (
-    x: ($spacer-x * 3),
-    y: ($spacer-y * 3)
-  )
+  0: 0,
+  1: ($spacer * .25),
+  2: ($spacer * .5),
+  3: $spacer,
+  4: ($spacer * 1.5),
+  5: ($spacer * 3)
 ) !default;
 $border-width: 1px !default;
 
@@ -191,7 +175,7 @@ $inverse-color: $gray-lighter !default;
 //
 // Style anchor elements.
 
-$link-color:            $brand-primary !default;
+$link-color:            theme-color("primary") !default;
 $link-decoration:       none !default;
 $link-hover-color:      darken($link-color, 15%) !default;
 $link-hover-decoration: underline !default;
@@ -323,7 +307,7 @@ $border-radius-lg:       0 !default; // ChangedLineForBootstrap4
 $border-radius-sm:       0 !default; // ChangedLineForBootstrap4
 
 $component-active-color: $white !default;
-$component-active-bg:    $brand-primary !default;
+$component-active-bg:    theme-color("primary") !default;
 
 $caret-width:            .3em !default;
 
@@ -364,11 +348,11 @@ $btn-padding-y:                  .5rem !default;
 $btn-line-height:                1.25 !default;
 $btn-font-weight:                300 !default; // ChangedLineForBootstrap4
 $btn-box-shadow:                 inset 0 1px 0 rgba($white,.15), 0 1px 1px rgba($black,.075) !default;
-$btn-focus-box-shadow:           0 0 0 2px rgba($brand-primary, .25) !default;
+$btn-focus-box-shadow:           0 0 0 2px rgba(theme-color("primary"), .25) !default;
 $btn-active-box-shadow:          inset 0 3px 5px rgba($black,.125) !default;
 
 $btn-primary-color:              $white !default;
-$btn-primary-bg:                 $brand-primary !default;
+$btn-primary-bg:                 theme-color("primary") !default;
 $btn-primary-border:             darken($btn-primary-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-secondary-color:            $gray !default; // ChangedLineForBootstrap4
@@ -376,19 +360,19 @@ $btn-secondary-bg:               $gray-lightest !default; // ChangedLineForBoots
 $btn-secondary-border:           darken($btn-secondary-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-info-color:                 $white !default;
-$btn-info-bg:                    $brand-info !default;
+$btn-info-bg:                    theme-color("info") !default;
 $btn-info-border:                darken($btn-info-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-success-color:              $white !default;
-$btn-success-bg:                 $brand-success !default;
+$btn-success-bg:                 theme-color("success") !default;
 $btn-success-border:             darken($btn-success-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-warning-color:              $white !default;
-$btn-warning-bg:                 $brand-warning !default;
+$btn-warning-bg:                 theme-color("warning") !default;
 $btn-warning-border:             darken($btn-warning-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-danger-color:               $white !default;
-$btn-danger-bg:                  $brand-danger !default;
+$btn-danger-bg:                  theme-color("danger") !default;
 $btn-danger-border:              darken($btn-danger-bg, 5%) !default; // ChangedLineForBootstrap4
 
 $btn-link-disabled-color:        $gray-light !default;
@@ -429,7 +413,7 @@ $input-border-radius-lg:         $border-radius-lg !default;
 $input-border-radius-sm:         $border-radius-sm !default;
 
 $input-bg-focus:                 $input-bg !default;
-$input-border-focus:             lighten($brand-primary, 25%) !default;
+$input-border-focus:             lighten(theme-color("primary"), 25%) !default;
 $input-box-shadow-focus:         $input-box-shadow, rgba($input-border-focus, .6) !default;
 $input-color-focus:              $input-color !default;
 
@@ -457,7 +441,7 @@ $form-check-input-margin-x: .25rem !default;
 
 $form-check-inline-margin-x: .75rem !default;
 
-$form-group-margin-bottom:       $spacer-y !default;
+$form-group-margin-bottom:       $spacer !default;
 
 $input-group-addon-bg:           $gray-lightest !default; // ChangedLineForBootstrap4
 $input-group-addon-border-color: $input-border-color !default;
@@ -479,19 +463,19 @@ $custom-control-disabled-indicator-bg:       $gray-lighter !default;
 $custom-control-disabled-description-color:  $gray-light !default;
 
 $custom-control-checked-indicator-color:      $white !default;
-$custom-control-checked-indicator-bg:         $brand-primary !default;
+$custom-control-checked-indicator-bg:         theme-color("primary") !default;
 $custom-control-checked-indicator-box-shadow: none !default;
 
-$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px $brand-primary !default;
+$custom-control-focus-indicator-box-shadow: 0 0 0 1px $body-bg, 0 0 0 3px theme-color("primary") !default;
 
 $custom-control-active-indicator-color:      $white !default;
-$custom-control-active-indicator-bg:         lighten($brand-primary, 35%) !default;
+$custom-control-active-indicator-bg:         lighten(theme-color("primary"), 35%) !default;
 $custom-control-active-indicator-box-shadow: none !default;
 
 $custom-checkbox-radius: $border-radius !default;
 $custom-checkbox-checked-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$custom-control-checked-indicator-color}' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26 2.974 7.25 8 2.193z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$custom-checkbox-indeterminate-bg: $brand-primary !default;
+$custom-checkbox-indeterminate-bg: theme-color("primary") !default;
 $custom-checkbox-indeterminate-indicator-color: $custom-control-checked-indicator-color !default;
 $custom-checkbox-indeterminate-icon: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 4'%3E%3Cpath stroke='#{$custom-checkbox-indeterminate-indicator-color}' d='M0 2h4'/%3E%3C/svg%3E"), "#", "%23") !default;
 $custom-checkbox-indeterminate-box-shadow: none !default;
@@ -514,7 +498,7 @@ $custom-select-border-width:  $input-btn-border-width !default;
 $custom-select-border-color:  $input-border-color !default;
 $custom-select-border-radius: $border-radius !default;
 
-$custom-select-focus-border-color: lighten($brand-primary, 25%) !default;
+$custom-select-focus-border-color: lighten(theme-color("primary"), 25%) !default;
 $custom-select-focus-box-shadow:   inset 0 1px 2px rgba($black, .075), 0 0 5px rgba($custom-select-focus-border-color, .5) !default;
 
 $custom-select-sm-padding-y:  .2rem !default;
@@ -522,7 +506,7 @@ $custom-select-sm-font-size:  75% !default;
 
 $custom-file-height:           2.5rem !default;
 $custom-file-width:            14rem !default;
-$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem $brand-primary !default;
+$custom-file-focus-box-shadow: 0 0 0 .075rem $white, 0 0 0 .2rem theme-color("primary") !default;
 
 $custom-file-padding-x:     .5rem !default;
 $custom-file-padding-y:     1rem !default;
@@ -546,13 +530,13 @@ $custom-file-text: (
 
 
 // Form validation icons
-$form-icon-success-color: $brand-success !default;
+$form-icon-success-color: theme-color("success") !default;
 $form-icon-success: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-success-color}' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-warning-color: $brand-warning !default;
+$form-icon-warning-color: theme-color("warning") !default;
 $form-icon-warning: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath fill='#{$form-icon-warning-color}' d='M4.4 5.324h-.8v-2.46h.8zm0 1.42h-.8V5.89h.8zM3.76.63L.04 7.075c-.115.2.016.425.26.426h7.397c.242 0 .372-.226.258-.426C6.726 4.924 5.47 2.79 4.253.63c-.113-.174-.39-.174-.494 0z'/%3E%3C/svg%3E"), "#", "%23") !default;
 
-$form-icon-danger-color: $brand-danger !default;
+$form-icon-danger-color: theme-color("danger") !default;
 $form-icon-danger: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='#{$form-icon-danger-color}' viewBox='-2 -2 7 7'%3E%3Cpath stroke='%23d9534f' d='M0 0l3 3m0-3L0 3'/%3E%3Ccircle r='.5'/%3E%3Ccircle cx='3' r='.5'/%3E%3Ccircle cy='3' r='.5'/%3E%3Ccircle cx='3' cy='3' r='.5'/%3E%3C/svg%3E"), "#", "%23") !default;
 
 
@@ -612,12 +596,12 @@ $navbar-toggler-padding-y:           .25rem !default;
 $navbar-toggler-font-size:           $font-size-lg !default;
 $navbar-toggler-border-radius:       $btn-border-radius !default;
 
-$navbar-inverse-color:                 rgba(255,255,255,.7) !default; // ChangedLineForBootstrap4
-$navbar-inverse-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
-$navbar-inverse-active-color:          rgba(255,255,255,1) !default;
-$navbar-inverse-disabled-color:        rgba(255,255,255,.25) !default;
-$navbar-inverse-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-inverse-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
-$navbar-inverse-toggler-border:        rgba($white,.1) !default;
+$navbar-dark-color:                 rgba(255,255,255,.7) !default; // ChangedLineForBootstrap4
+$navbar-dark-hover-color:           rgba(255,255,255,1) !default; // ChangedLineForBootstrap4
+$navbar-dark-active-color:          rgba(255,255,255,1) !default;
+$navbar-dark-disabled-color:        rgba(255,255,255,.25) !default;
+$navbar-dark-toggler-bg: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath stroke='#{$navbar-dark-color}' stroke-width='2' stroke-linecap='round' stroke-miterlimit='10' d='M4 8h24M4 16h24M4 24h24'/%3E%3C/svg%3E"), "#", "%23") !default;
+$navbar-dark-toggler-border:        rgba($white,.1) !default;
 
 $navbar-light-color:                rgba($black,.5) !default;
 $navbar-light-hover-color:          rgba($black,.7) !default;
@@ -669,7 +653,7 @@ $pagination-hover-bg:                  $gray-lightest !default; // ChangedLineFo
 $pagination-hover-border:              #ddd !default;
 
 $pagination-active-color:              $white !default;
-$pagination-active-bg:                 $brand-primary !default;
+$pagination-active-bg:                 theme-color("primary") !default;
 $pagination-active-border:             $btn-primary-border !default; // ChangedLineForBootstrap4
 
 $pagination-disabled-color:            $gray-lighter !default; // ChangedLineForBootstrap4
@@ -688,20 +672,20 @@ $jumbotron-bg:                   $gray-lightest !default; // ChangedLineForBoots
 // Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             #fff !default; // ChangedLineForBootstrap4
-$state-success-bg:               $brand-success !default; // ChangedLineForBootstrap4
+$state-success-bg:               theme-color("success") !default; // ChangedLineForBootstrap4
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                #fff !default; // ChangedLineForBootstrap4
-$state-info-bg:                  $brand-info !default; // ChangedLineForBootstrap4
+$state-info-bg:                  theme-color("info") !default; // ChangedLineForBootstrap4
 $state-info-border:              darken($state-info-bg, 7%) !default;
 
 $state-warning-text:             #fff !default; // ChangedLineForBootstrap4
-$state-warning-bg:               $brand-warning !default; // ChangedLineForBootstrap4
+$state-warning-bg:               theme-color("warning") !default; // ChangedLineForBootstrap4
 $mark-bg:                        $state-warning-bg !default;
 $state-warning-border:           darken($state-warning-bg, 5%) !default;
 
 $state-danger-text:              #fff !default; // ChangedLineForBootstrap4
-$state-danger-bg:                $brand-danger !default; // ChangedLineForBootstrap4
+$state-danger-bg:                theme-color("danger") !default; // ChangedLineForBootstrap4
 $state-danger-border:            darken($state-danger-bg, 5%) !default;
 
 
@@ -767,11 +751,11 @@ $popover-arrow-outer-color:           fade-in($popover-border-color, .05) !defau
 // Badges
 
 $badge-default-bg:            $gray-light !default;
-$badge-primary-bg:            $brand-primary !default;
-$badge-success-bg:            $brand-success !default;
-$badge-info-bg:               $brand-info !default;
-$badge-warning-bg:            $brand-warning !default;
-$badge-danger-bg:             $brand-danger !default;
+$badge-primary-bg:            theme-color("primary") !default;
+$badge-success-bg:            theme-color("success") !default;
+$badge-info-bg:               theme-color("info") !default;
+$badge-warning-bg:            theme-color("warning") !default;
+$badge-danger-bg:             theme-color("danger") !default;
 
 $badge-color:                 $white !default;
 $badge-link-hover-color:      $white !default;
@@ -823,7 +807,7 @@ $modal-transition:            transform .3s ease-out !default;
 
 $alert-padding-x:             1.25rem !default;
 $alert-padding-y:             .75rem !default;
-$alert-margin-bottom:         $spacer-y !default;
+$alert-margin-bottom:         $spacer !default;
 $alert-border-radius:         $border-radius !default;
 $alert-link-font-weight:      $font-weight-bold !default;
 $alert-border-width:          $border-width !default;
@@ -852,8 +836,8 @@ $progress-font-size:            .75rem !default;
 $progress-bg:                   #f6f6f6 !default; // ChangedLineForBootstrap4
 $progress-border-radius:        $border-radius !default;
 $progress-box-shadow:           inset 0 .1rem .1rem rgba($black,.1) !default;
-$progress-bar-color:            $brand-primary !default; // ChangedLineForBootstrap4
-$progress-bar-bg:               $brand-primary !default;
+$progress-bar-color:            theme-color("primary") !default; // ChangedLineForBootstrap4
+$progress-bar-bg:               theme-color("primary") !default;
 $progress-bar-animation-timing: 1s linear infinite !default;
 
 // List group

--- a/yeti/_variables.scss
+++ b/yeti/_variables.scss
@@ -120,7 +120,7 @@ $theme-colors: (
   "danger": #F04124,
   "light": $gray-light,
   "dark": $gray-dark
-);
+) !default;
 
 
 // Options


### PR DESCRIPTION
I went ahead and did a basic port of the Saas files to bootstrap v4 beta.

Basically:
* Replace `$brand-*` definitions with `$theme-colors()`
* Use `theme-color("..")` instead of `$band-*` for substitutions
* Replace `$spacers` with new syntax
* Replace `$spacer-y` with `$spacer` wherever it's used
* Drop `$spacer-x`
* Replace all `navbar-inverse-*` with `navbar-dark-*`

I'm able to compile all themes with
```
// core bootstrap functions
@import "bootstrap/scss/functions";
@import "bootstrap/scss/mixins";

// bootswatch variable overrides
@import "bootswatch/cerulean/variables";

// full bootstrap mumbo humbo
@import "bootstrap/scss/bootstrap";

// bootswatch style overrides
@import "bootswatch/cerulean/bootswatch";
```
And as far as I can tell, everything looks quite normal. Just did a basic click-through test on all themes in my application, so I really didn't test all components - some stuff might still be missing.

Also, there are some leftovers like $inverse-bg which doesn't really seem to be used anywhere.
So this serves more as a start, rather than a full clean port, but it might be helpful anyway.

