### PR TITLE
V4 compile fixes

### DIFF
--- a/materia/_variables.scss
+++ b/materia/_variables.scss
@@ -78,7 +78,7 @@ $nav-tabs-border-color:                       transparent !default;
 
 // Navbar
 
-$navbar-padding-y:                  $spacer !default;
+$navbar-padding-y:                  1rem !default;
 
 $navbar-dark-color:                 rgba($white,.75) !default;
 $navbar-dark-hover-color:           $white !default;

--- a/minty/_variables.scss
+++ b/minty/_variables.scss
@@ -1,4 +1,4 @@
--// Minty 4.0.0
+// Minty 4.0.0
 // Bootswatch
 
 //


### PR DESCRIPTION
This fixes two compile errors after latest commits in the v4 branch:

- removes a leading - before // comment in minty
- replaces undefined $spacer variable in materia with static value (bootstrap's _variables.scss needs to be imported after materia's, so $spacer is not defined). Alternatively, $spacer could be defined.