### PR TITLE
Add gemspec

### DIFF
--- a/bootswatch.gemspec
+++ b/bootswatch.gemspec
@@ -1,0 +1,14 @@
+require "json"
+$package = JSON.parse(File.read(File.expand_path("package.json", __dir__)))
+
+Gem::Specification.new do |s|
+  s.name        = "bootswatch"
+  s.version     = $package["version"]
+  s.author      = $package["author"]
+  s.homepage    = $package["homepage"]
+  s.summary     = $package["description"]
+  s.license     = $package["license"]
+
+  s.files = Dir["{dist}/**/*", "LICENSE", "README.md", "package.json"]
+  s.require_paths = ["dist"]
+end


### PR DESCRIPTION
I'd like to propose adding a .gemspec file to the repo.  Doing so would give Rubyists an easy way to access the most up-to-date version of any theme by adding the following to their Gemfile:

```ruby
gem "bootswatch", github: "thomaspark/bootswatch"
```

Furthermore, Rails users can then add the following line to an initializer:

```ruby
Rails.application.config.assets.paths += Gem.loaded_specs["bootswatch"].load_paths
```

And thus be able to import themes via any SCSS asset like so:

```scss
@import "materia/variables";
@import "materia/bootswatch";
```

The `bootswatch.gemspec` file I've included in this PR dynamically pulls all its metadata from `package.json`.  Thus it should not need to be updated, and should not pose an extra maintainence burden.  Any time you update `package.json`, the changes will be reflected in `bootswatch.gemspec` when the Ruby package manager fetches the git repo.

If you'd like, I can also add some of the above information to the documentation.  I wasn't sure of the best place to add it...  In the README?  Under a particular section in `docs/help/index.html`?  Elsewhere?

p.s. Thank you for all of these amazing Bootstrap themes, and all of your hard work in maintaining them!
