### PR TITLE
Coerce version number to Bundler-accepted format

### DIFF
--- a/bootswatch.gemspec
+++ b/bootswatch.gemspec
@@ -3,7 +3,7 @@ $package = JSON.parse(File.read(File.expand_path("package.json", __dir__)))
 
 Gem::Specification.new do |s|
   s.name        = "bootswatch"
-  s.version     = $package["version"]
+  s.version     = $package["version"].tr("+", ".")
   s.author      = $package["author"]
   s.homepage    = $package["homepage"]
   s.summary     = $package["description"]


### PR DESCRIPTION
Follow-up to #822 

The Ruby package manager, Bundler, chokes on the "+" in a version number like "4.1.0+1".  This fix translates "+" to "." in the version number read from package.json.

Sorry for not anticipating this problem! :sweat:

