### PR TITLE
Cyborg theme: Add two additional form color settings

### DIFF
--- a/dist/cyborg/_bootswatch.scss
+++ b/dist/cyborg/_bootswatch.scss
@@ -114,7 +114,9 @@ table {
 // Forms =======================================================================
 
 legend,
-.input-group-addon {
+.input-group-addon,
+.input-group-text,
+.custom-file-label::after {
   color: #fff;
 }
 


### PR DESCRIPTION
This adds `color: white` to `.input-group-text` and `.custom-file-label::after` which are needed to make pieces of input addons and file uploads show properly.

Before: 

![screen shot 2018-05-14 at 11 34 25 am](https://user-images.githubusercontent.com/55392/40016432-1de83aea-576b-11e8-8b77-2241fce2f476.png)

After:

![screen shot 2018-05-14 at 11 36 31 am](https://user-images.githubusercontent.com/55392/40016439-23e4d494-576b-11e8-9989-57b316bf9ded.png)

