### PR TITLE
Custom switch corrected

### DIFF
--- a/dist/lux/bootstrap.css
+++ b/dist/lux/bootstrap.css
@@ -3987,10 +3987,10 @@ input[type="button"].btn-block {
 }
 
 .custom-switch .custom-control-label::after {
-  top: calc(0.15625rem + 0);
-  left: calc(-2.25rem + 0);
-  width: calc(1rem - 0);
-  height: calc(1rem - 0);
+  top: 0.15625rem;
+  left: -2.25rem;
+  width: 1rem;
+  height: 1rem;
   background-color: #adb5bd;
   border-radius: 0.5rem;
   -webkit-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out, -webkit-box-shadow 0.15s ease-in-out;


### PR DESCRIPTION
Custom switch does not render correctly with calc
also doesnt make sense to add/sub by 0
chrome errors on this causing them to not be in the right place

original:
checked: https://i.gyazo.com/b35502499163196a0e49d2b9ffec6f60.png
unchecked: https://i.gyazo.com/79e93e58250a6facfb8d0b8fbf8d4168.png
css: https://i.gyazo.com/a6d73f114db4af9bed2716506907d650.png

revised:
checked: https://i.gyazo.com/67a0fd25d1811564f6743b93e178059e.png
unchecked: https://i.gyazo.com/2d904b178f02475b129a38de2cd960c6.png
css: https://i.gyazo.com/1c5d20463953d63a937183921ea65631.png