### PR TITLE
Fixed button large size in Litera theme

### DIFF
--- a/dist/litera/bootstrap.css
+++ b/dist/litera/bootstrap.css
@@ -3186,7 +3186,7 @@ fieldset:disabled a.btn {
 
 .btn-lg, .btn-group-lg > .btn {
   padding: 0.5rem 1rem;
-  font-size: 1.32875rem;
+  font-size: 1.32875rem !important;
   line-height: 1.5;
   border-radius: 0.3rem;
 }


### PR DESCRIPTION
For [Litera theme](https://bootswatch.com/litera/).

Example:
```html
<button class="btn">Default button</button>
<button class="btn btn-lg">Large button</button>
```

Before:
![image](https://user-images.githubusercontent.com/2198826/53436821-17cff000-3a0d-11e9-8150-557ee87e84a0.png)
After:
![image](https://user-images.githubusercontent.com/2198826/53436846-261e0c00-3a0d-11e9-8321-ee1920b1cc53.png)
