### PR TITLE
fix remote font imports for less 3 again

### DIFF
--- a/cosmo/bootswatch.less
+++ b/cosmo/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/cyborg/bootswatch.less
+++ b/cyborg/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/darkly/bootswatch.less
+++ b/darkly/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/flatly/bootswatch.less
+++ b/flatly/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/journal/bootswatch.less
+++ b/journal/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=News+Cycle:400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/lumen/bootswatch.less
+++ b/lumen/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,400italic";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/paper/bootswatch.less
+++ b/paper/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/readable/bootswatch.less
+++ b/readable/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Raleway:400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/sandstone/bootswatch.less
+++ b/sandstone/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Roboto:400,500,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/simplex/bootswatch.less
+++ b/simplex/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/spacelab/bootswatch.less
+++ b/spacelab/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/superhero/bootswatch.less
+++ b/superhero/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Lato:300,400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/united/bootswatch.less
+++ b/united/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Ubuntu:400,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 

--- a/yeti/bootswatch.less
+++ b/yeti/bootswatch.less
@@ -5,7 +5,7 @@
 @web-font-path: "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700";
 
 .web-font(@path) {
-  @import url("@{path}");
+  @import (css) url("@{path}");
 }
 .web-font(@web-font-path);
 


### PR DESCRIPTION
Bootswatch 3 won't compile under less 3 as reported in 
* https://github.com/thomaspark/bootswatch/issues/841
* https://github.com/thomaspark/bootswatch/issues/842

A fixed was made on 15/6/18 by: https://github.com/thomaspark/bootswatch/commit/5467d71dc140144eb452acfa761b879fe869da29, but the fix was never actually applied the v3 branch.

So Bootswatch 3.4.1, released after the fix on 13/2/19, is still incompatible with less 3.

This fix adds the original fix to the v3 branch.

Since there probably won't be a bootstrap 3.4.2, at least not in the near future, maybe you could release a 3.4.1+1 wit this fix?