### PR TITLE
remove unused btn font size

### DIFF
--- a/dist/litera/_bootswatch.scss
+++ b/dist/litera/_bootswatch.scss
@@ -35,7 +35,7 @@ $font-family-serif:      Georgia, Cambria, "Times New Roman", Times, serif !defa
 .btn {
   border-radius: 1.078em;
   font-family: $font-family-sans-serif;
-  font-size: 0.875em;
+  font-size: 0.875rem;
 
   &-lg {
     border-radius: 2.688em;


### PR DESCRIPTION
Hello,

I don't know if it's the good way to fix it: 
The size of this button is unused except if it's under a title (like `<h1>`) element. In this case, the button is too big. 

Example with an application generate with JHipster and litera bootswatch theme:

Here the button in `<h2>` element: (`font-size: 0.875em` is used and too big)
```html
<h2>
    <span>Health Checks</span>
    <button class="btn btn-primary float-right">
        <fa-icon [icon]="'sync'"></fa-icon> <span>Refresh</span>
    </button>
</h2>
```

![image](https://user-images.githubusercontent.com/17801784/60569894-a9ab8900-9d70-11e9-86cb-0963fb56fae7.png)

Here the button after `<h2>` element: (`font-size: 0.875em` is **not** used and it's expected)
```html
<h2>
    <span>Health Checks</span>
</h2>
<button class="btn btn-primary float-right">
    <fa-icon [icon]="'sync'"></fa-icon> <span>Refresh</span>
</button>
```

![image](https://user-images.githubusercontent.com/17801784/60570249-76b5c500-9d71-11e9-89ac-9f260b2cf47e.png)
