### PR TITLE
Change the Theme Primary Background to Primary Color

### DIFF
--- a/dist/lux/_bootswatch.scss
+++ b/dist/lux/_bootswatch.scss
@@ -27,7 +27,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Nunito+Sans:400,600" !d
 }
 
 .bg-primary {
-  background-color: $gray-900 !important;
+  background-color: theme-color("primary") !important;
 }
 
 .bg-light {

--- a/docs/4/lux/_bootswatch.scss
+++ b/docs/4/lux/_bootswatch.scss
@@ -27,7 +27,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Nunito+Sans:400,600" !d
 }
 
 .bg-primary {
-  background-color: $gray-900 !important;
+  background-color: theme-color("primary") !important;
 }
 
 .bg-light {


### PR DESCRIPTION
I noticed that changing the primary theme color by overriding the primary color variable doesn't affects some of the elements backgound color. This happens because the .bg-primary is using gray-900 variable rather than primary variable. Although the primary variable is pointing to the same grey-900 variable, but changing the value of the primary variable doesn't change the .bg-primary. This change (commit) fixed that, and makes changing the theme primary color (including bg-primary) easy by only overriding the value of a single variable (primary).