### PR TITLE
fix: card header colors with bg-$color for darkly theme

### DIFF
--- a/dist/darkly/_bootswatch.scss
+++ b/dist/darkly/_bootswatch.scss
@@ -224,7 +224,7 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic&
 .card {
   @each $color, $value in $theme-colors {
     &.bg-#{$color} .card-header {
-        background-color: darken($value, 5%);
+        background-color: lighten($value, 5%);
     }
   }
 }

--- a/dist/darkly/_bootswatch.scss
+++ b/dist/darkly/_bootswatch.scss
@@ -218,3 +218,13 @@ $web-font-path: "https://fonts.googleapis.com/css?family=Lato:400,700,400italic&
     color: #fff;
   }
 }
+
+// Cards =======================================================================
+
+.card {
+  @each $color, $value in $theme-colors {
+    &.bg-#{$color} .card-header {
+        background-color: darken($value, 5%);
+    }
+  }
+}


### PR DESCRIPTION
Cards with a bg-$color class have a dark gray header background instead of an appropriate theme-color.