### PR TITLE
HTML cleanup

### DIFF
--- a/docs/2/amelia/index.html
+++ b/docs/2/amelia/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -876,7 +876,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -896,7 +896,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/cerulean/index.html
+++ b/docs/2/cerulean/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/cosmo/index.html
+++ b/docs/2/cosmo/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/cyborg/index.html
+++ b/docs/2/cyborg/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -876,7 +876,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -896,7 +896,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/default/index.html
+++ b/docs/2/default/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -867,7 +867,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -887,7 +887,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/flatly/index.html
+++ b/docs/2/flatly/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -869,7 +869,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -889,7 +889,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/index.html
+++ b/docs/2/index.html
@@ -15,13 +15,13 @@
   <link href="default/bootstrap-responsive.min.css" rel="stylesheet">
   <link href="css/font-awesome.min.css" rel="stylesheet">
   <link href="css/bootswatch.css" rel="stylesheet">
-  <link href="http://feeds.feedburner.com/bootswatch" rel="alternate" type="application/rss+xml" title="Bootswatch">
+  <link href="https://feeds.feedburner.com/bootswatch" rel="alternate" type="application/rss+xml" title="Bootswatch">
 
   <script>
 
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-23019901-1']);
-    _gaq.push(['_setDomainName', "bootswatch.com"]);
+    _gaq.push(['_setDomainName', 'bootswatch.com']);
     _gaq.push(['_setAllowLinker', true]);
     _gaq.push(['_trackPageview']);
 
@@ -98,7 +98,7 @@
         <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://bootswatch.com" data-via="thomashpark">Tweet</a>
       </span>
       <span>
-        <a class="btn rss-button" href="http://feeds.feedburner.com/bootswatch"><i class="icon-rss"></i> RSS</a>
+        <a class="btn rss-button" href="https://feeds.feedburner.com/bootswatch"><i class="icon-rss"></i> RSS</a>
       </span>
     </div>
 
@@ -132,7 +132,7 @@
       </div>
       <div class="span4">
         <h3><i class="icon-bullhorn"></i> Stay Updated</h3>
-        <p>Be notified about updates by subscribing via <a href="http://feeds.feedburner.com/bootswatch">RSS feed</a>, <a href="http://feedburner.google.com/fb/a/mailverify?uri=bootswatch&amp;loc=en_US">email</a>, or <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Tumblr</a>.</p>
+        <p>Be notified about updates by subscribing via <a href="https://feeds.feedburner.com/bootswatch">RSS feed</a>, <a href="http://feedburner.google.com/fb/a/mailverify?uri=bootswatch&amp;loc=en_US">email</a>, or <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Tumblr</a>.</p>
       </div>
     </div>
 
@@ -597,7 +597,7 @@
       <p class="pull-right"><a href="#top">Back to top</a></p>
       <div class="links">
         <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-        <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+        <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
         <a href="https://twitter.com/thomashpark">Twitter</a>
         <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
         <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3Bvar%20r%3D%27%3Clink%20rel%3D%22stylesheet%22%20href%3D%22http://bootswatch.com/default/bootstrap-responsive.min.css%22%3E%27%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27%2Br)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -631,7 +631,7 @@
     var line = Math.floor((taglines.length) * Math.random());
     $('#tagline').html(taglines[line]);
 
-    parseRSS('http://feeds.feedburner.com/bootswatch', function(d){
+    parseRSS('https://feeds.feedburner.com/bootswatch', function(d){
       var h ='<strong>Recent news:</strong> ';
       for (var i = 0; i < 3; i++){
         h = h + '<a href="' + d.entries[i].link + '" onclick="pageTracker._link(this.href); return false;">' + d.entries[i].title + '...</a>&nbsp;&nbsp;';

--- a/docs/2/journal/index.html
+++ b/docs/2/journal/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/readable/index.html
+++ b/docs/2/readable/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/simplex/index.html
+++ b/docs/2/simplex/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/slate/index.html
+++ b/docs/2/slate/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/spacelab/index.html
+++ b/docs/2/spacelab/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/spruce/index.html
+++ b/docs/2/spruce/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/superhero/index.html
+++ b/docs/2/superhero/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/2/swatchmaker/test/test.html
+++ b/docs/2/swatchmaker/test/test.html
@@ -20,7 +20,7 @@
   </head>
 
   <body id="top" class="preview" data-spy="scroll" data-target=".subnav" data-offset="80">
-    <script src="http://bootswatch.com/js/bsa.js"></script>
+    <script src="https://bootswatch.com/js/bsa.js"></script>
 
 
   <!-- Navbar

--- a/docs/2/united/index.html
+++ b/docs/2/united/index.html
@@ -19,10 +19,10 @@
 
    <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -868,7 +868,7 @@
         <p class="pull-right"><a href="#top">Back to top</a></p>
         <div class="links">
           <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a>
-          <a href="http://feeds.feedburner.com/bootswatch">RSS</a>
+          <a href="https://feeds.feedburner.com/bootswatch">RSS</a>
           <a href="https://twitter.com/thomashpark">Twitter</a>
           <a href="https://github.com/thomaspark/bootswatch/">GitHub</a>
           <a rel="tooltip" href="javascript:(function(e,a,g,h,f,c,b,d)%7Bif(!(f%3De.jQuery)%7C%7Cg%3Ef.fn.jquery%7C%7Ch(f))%7Bc%3Da.createElement(%22script%22)%3Bc.type%3D%22text/javascript%22%3Bc.src%3D%22http://ajax.googleapis.com/ajax/libs/jquery/%22%2Bg%2B%22/jquery.min.js%22%3Bc.onload%3Dc.onreadystatechange%3Dfunction()%7Bif(!b%26%26(!(d%3Dthis.readyState)%7C%7Cd%3D%3D%22loaded%22%7C%7Cd%3D%3D%22complete%22))%7Bh((f%3De.jQuery).noConflict(1),b%3D1)%3Bf(c).remove()%7D%7D%3Ba.documentElement.childNodes%5B0%5D.appendChild(c)%7D%7D)(window,document,%221.3.2%22,function(%24,L)%7Bif(%24(%22.bootswatcher%22)%5B0%5D)%7B%24(%22.bootswatcher%22).remove()%7Delse%7Bvar%20%24e%3D%24(%27%3Cselect%20class%3D%22bootswatcher%22%3E%3Coption%3EAmelia%3C/option%3E%3Coption%3ECerulean%3C/option%3E%3Coption%3ECosmo%3C/option%3E%3Coption%3ECyborg%3C/option%3E%3Coption%3EJournal%3C/option%3E%3Coption%3EReadable%3C/option%3E%3Coption%3ESimplex%3C/option%3E%3Coption%3ESlate%3C/option%3E%3Coption%3ESpacelab%3C/option%3E%3Coption%3ESpruce%3C/option%3E%3Coption%3ESuperhero%3C/option%3E%3Coption%3EUnited%3C/option%3E%3C/select%3E%27)%3Bvar%20l%3D1%2BMath.floor(Math.random()*%24e.children().length)%3B%24e.css(%7B%22z-index%22:%2299999%22,position:%22fixed%22,top:%225px%22,right:%225px%22,opacity:%220.5%22%7D).hover(function()%7B%24(this).css(%22opacity%22,%221%22)%7D,function()%7B%24(this).css(%22opacity%22,%220.5%22)%7D).change(function()%7Bif(!%24(%22link.bootswatcher%22)%5B0%5D)%7B%24(%22head%22).append(%27%3Clink%20rel%3D%22stylesheet%22%20class%3D%22bootswatcher%22%3E%27)%7D%24(%22link.bootswatcher%22).attr(%22href%22,%22http://bootswatch.com/%22%2B%24(this).find(%22:selected%22).text().toLowerCase()%2B%22/bootstrap.min.css%22)%7D).find(%22option:nth-child(%22%2Bl%2B%22)%22).attr(%22selected%22,%22selected%22).end().trigger(%22change%22)%3B%24(%22body%22).append(%24e)%7D%3B%7D)%3B" title="Drag to your bookmarks bar">Bookmarklet</a>
@@ -888,7 +888,7 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="../js/jquery.smooth-scroll.min.js"></script>
     <script src="../js/bootstrap.min.js"></script>
     <script src="../js/bootswatch.js"></script>

--- a/docs/3/cerulean/index.html
+++ b/docs/3/cerulean/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cerulean</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/cosmo/index.html
+++ b/docs/3/cosmo/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cosmo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/custom/index.html
+++ b/docs/3/custom/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Custom</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/cyborg/index.html
+++ b/docs/3/cyborg/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cyborg</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/darkly/index.html
+++ b/docs/3/darkly/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Darkly</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/default/index.html
+++ b/docs/3/default/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Default</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -537,7 +537,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1271,7 +1271,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/flatly/index.html
+++ b/docs/3/flatly/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Flatly</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/help/index.html
+++ b/docs/3/help/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Help</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../flatly/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -32,9 +32,9 @@
     </style>
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
@@ -178,7 +178,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/index.html
+++ b/docs/3/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Free themes for Bootstrap</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./flatly/bootstrap.css" media="screen">
     <link rel="stylesheet" href="./bower_components/font-awesome/css/font-awesome.min.css">
     <link rel="stylesheet" href="./assets/css/custom.min.css">
@@ -15,10 +15,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -141,7 +141,7 @@
           </div>
           <div class="col-lg-4 col-sm-6">
             <h3><i class="fa fa-bullhorn"></i> Stay Updated</h3>
-            <p>Be notified about updates by subscribing via <a href="http://feeds.feedburner.com/bootswatch">RSS feed</a>, <a href="http://feedburner.google.com/fb/a/mailverify?uri=bootswatch&amp;loc=en_US">email</a>, or <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Tumblr</a>.</p>
+            <p>Be notified about updates by subscribing via <a href="https://feeds.feedburner.com/bootswatch">RSS feed</a>, <a href="http://feedburner.google.com/fb/a/mailverify?uri=bootswatch&amp;loc=en_US">email</a>, or <a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Tumblr</a>.</p>
           </div>
         </div>
 
@@ -765,7 +765,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="./help/#api">API</a></li>

--- a/docs/3/journal/index.html
+++ b/docs/3/journal/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Journal</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/lumen/index.html
+++ b/docs/3/lumen/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Lumen</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/paper/index.html
+++ b/docs/3/paper/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Paper</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/readable/index.html
+++ b/docs/3/readable/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Readable</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/sandstone/index.html
+++ b/docs/3/sandstone/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Sandstone</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/simplex/index.html
+++ b/docs/3/simplex/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Simplex</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/slate/index.html
+++ b/docs/3/slate/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Slate</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/spacelab/index.html
+++ b/docs/3/spacelab/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Spacelab</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/superhero/index.html
+++ b/docs/3/superhero/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Superhero</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/tests/components.html
+++ b/docs/3/tests/components.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Components</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../bower_components/bootstrap/dist/css/bootstrap.css" media="screen" id="stylesheet">
     <style>
 
@@ -2622,7 +2622,7 @@
               </div>
           </div>
         </div>
-        
+
       </div>
 
 

--- a/docs/3/tests/thumbnail.html
+++ b/docs/3/tests/thumbnail.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Default Bootstrap</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../default/bootstrap.css" media="screen" id="stylesheet">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -94,7 +94,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/mustache.js/0.7.2/mustache.min.js"></script>
     <script>
 
-      $.get("http://api.bootswatch.com/3/", function (data) {
+      $.get("https://api.bootswatch.com/3/", function (data) {
           var menuTemplate = "<div id='menu' style='position:fixed;top:10px;right:10px;'><select>{{#.}}<option data-description='{{description}}'>{{name}}</option>{{/.}}</select></div>",
               menuHTML = Mustache.render(menuTemplate, data.themes);
 

--- a/docs/3/united/index.html
+++ b/docs/3/united/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: United</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/3/yeti/index.html
+++ b/docs/3/yeti/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Yeti</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./bootstrap.css" media="screen">
     <link rel="stylesheet" href="../assets/css/custom.min.css">
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -14,10 +14,10 @@
     <![endif]-->
     <script>
 
-     var _gaq = _gaq || [];
+      var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -539,7 +539,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>
@@ -1273,7 +1273,7 @@
             <ul class="list-unstyled">
               <li class="pull-right"><a href="#top">Back to top</a></li>
               <li><a href="http://news.bootswatch.com" onclick="pageTracker._link(this.href); return false;">Blog</a></li>
-              <li><a href="http://feeds.feedburner.com/bootswatch">RSS</a></li>
+              <li><a href="https://feeds.feedburner.com/bootswatch">RSS</a></li>
               <li><a href="https://twitter.com/bootswatch">Twitter</a></li>
               <li><a href="https://github.com/thomaspark/bootswatch/">GitHub</a></li>
               <li><a href="../help/#api">API</a></li>

--- a/docs/cerulean/index.html
+++ b/docs/cerulean/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cerulean</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/cerulean/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Cerulean <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/9y480qo5/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/9y480qo5/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/cerulean/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/cerulean/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>

--- a/docs/cosmo/index.html
+++ b/docs/cosmo/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cosmo</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/cosmo/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Cosmo <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/h3fgn55j/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/h3fgn55j/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/cosmo/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/cosmo/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>

--- a/docs/cyborg/index.html
+++ b/docs/cyborg/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Cyborg</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/cyborg/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Cyborg <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/q0gdqa1q/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/q0gdqa1q/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/cyborg/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/cyborg/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/darkly/index.html
+++ b/docs/darkly/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Darkly</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/darkly/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Darkly <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/1172d9hh/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/1172d9hh/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/darkly/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/darkly/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/default/index.html
+++ b/docs/default/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Default</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../_vendor/bootstrap/dist/css/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Default <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/mLascy62/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/mLascy62/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../_vendor/bootstrap/dist/css/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../_vendor/bootstrap/dist/css/bootstrap.css" download>bootstrap.css</a>
@@ -92,7 +92,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>

--- a/docs/flatly/index.html
+++ b/docs/flatly/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Flatly</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/flatly/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Flatly <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/jmg3gykg/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/jmg3gykg/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/flatly/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/flatly/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/help/index.html
+++ b/docs/help/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Bootswatch: Help</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/materia/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <style>
@@ -27,9 +27,9 @@
     </style>
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
       _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
@@ -43,10 +43,10 @@
   </head>
   <body id="help">
 
-    
+
     <div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary">
       <div class="container">
-        <a href="../" class="navbar-brand"><img src="../_assets/img/logo-nav.svg"> Bootswatch</a>
+        <a href="../" class="navbar-brand"><img src="../_assets/img/logo-nav.svg" alt=""> Bootswatch</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -97,7 +97,7 @@
         <div class="col-lg-9">
             <h1 id="quickstart">Quick Start</h1>
             <h4>Pre-Compiled CSS</h4>
-            <p>Using the themes is as easy as downloading a CSS file and replacing the one that comes with <a href="https://getbootstrap.com" target="_blank">Bootstrap</a>.</p>
+            <p>Using the themes is as easy as downloading a CSS file and replacing the one that comes with <a href="https://getbootstrap.com" rel="noopener" target="_blank">Bootstrap</a>.</p>
             <h4>Package</h4>
             <p>You can install as a package via npm with the command <code>npm install bootswatch</code>.</p>
             <p>
@@ -108,7 +108,7 @@
             <p>Before continuing, ensure you've run npm install bootswatch in your local project folder. (Use either npm or yarn.)</p>
             <p>Add the following import to your top-level <code>index.js</code> (or <code>App.js</code>) file. Add it before any other .css imports.</p>
             <pre>
-import "bootswatch/dist/[theme]/bootstrap.min.css"; 
+import "bootswatch/dist/[theme]/bootstrap.min.css";
 // TODO: Note: Replace ^[theme]^ (examples: darkly, slate, cosmo, spacelab, and superhero. See https://bootswatch.com for current theme names.)
 </pre>
             <p>Here's an example of updated imports in <code>App.js</code> to use "slate" theme (using a create-react-app fresh project.)</p>
@@ -123,7 +123,7 @@ function App() {
 </pre>
             </p>
             <h4>CDN</h4>
-            <p>You can also hotlink the themes via CDN at <a href="http://www.bootstrapcdn.com/bootswatch/">BootstrapCDN</a>.</p>
+            <p>You can also hotlink the themes via CDN at <a href="https://www.bootstrapcdn.com/bootswatch/">BootstrapCDN</a>.</p>
             <h4>Sass</h4>
             <p>If you're using Sass in your project, you can import the <code>_variables.scss</code> and <code>_bootswatch.scss</code> files for a given theme. This method allows you to override theme variables. Make sure to import Bootstrap's <code>bootstrap.scss</code> in between <code>_variables.scss</code> and <code>_bootswatch.scss</code>!</p>
             <pre>
@@ -140,16 +140,16 @@ function App() {
         <div class="row">
           <div class="col-lg-9">
             <h1 id="customization">Customization</h1>
-            <p>To modify a theme or create your own, follow the steps below in your terminal. You'll need to have <a href="https://help.github.com/articles/set-up-git" target="_blank">Git</a> and <a href="http://nodejs.org/" target="_blank">Node</a> installed.</p>
+            <p>To modify a theme or create your own, follow the steps below in your terminal. You'll need to have <a href="https://help.github.com/articles/set-up-git" rel="noopener" target="_blank">Git</a> and <a href="https://nodejs.org/" rel="noopener" target="_blank">Node</a> installed.</p>
             <ol>
               <li><p>Download the repository: <code>git clone https://github.com/thomaspark/bootswatch.git</code></p></li>
               <li><p>Install dependencies: <code>npm install</code></p></li>
-              <li><p>Make sure that you have <code>grunt</code> available in the command line. You can install <code>grunt-cli</code> as described on the <a href="http://gruntjs.com/getting-started">Grunt Getting Started page</a>.</p></li>
+              <li><p>Make sure that you have <code>grunt</code> available in the command line. You can install <code>grunt-cli</code> as described on the <a href="https://gruntjs.com/getting-started">Grunt Getting Started page</a>.</p></li>
               <li><p>In <code>/dist</code>, modify <code>_variables.scss</code> and <code>_bootswatch.scss</code> in one of the theme directories, or duplicate a theme directory to create a new one.</p></li>
               <li><p>Type <code>grunt swatch:[theme]</code> to build the CSS for a theme, e.g., <code>grunt swatch:flatly</code> for Flatly. Or type <code>grunt swatch</code> to build them all at once. </p></li>
               <li><p>You can run <code>grunt</code> to start a server, watch for any changes to the SASS files, and automatically build a theme and reload it on change. Run <code>grunt server</code> for just the server, and <code>grunt watch</code> for just the watcher.</p></li>
             </ol>
-            <p>Here are additional tips for <a href="http://www.smashingmagazine.com/2013/03/12/customizing-bootstrap/" target="_blank">customizing Bootstrap</a>.</p>
+            <p>Here are additional tips for <a href="https://www.smashingmagazine.com/2013/03/12/customizing-bootstrap/" rel="noopener" target="_blank">customizing Bootstrap</a>.</p>
             <p>If you prefer a web interface for customizing themes, check out <a href="https://bootstrap.build/">Bootstrap.build</a>. From within the builder, you can click the Import button to load the Bootswatch theme of your choice as a starting point.</p>
           </div>
         </div>
@@ -171,7 +171,7 @@ function App() {
               <li><code>scss</code></li>
               <li><code>scssVariables</code></li>
             </ul>
-            <p>Here's a <a href="http://jsbin.com/momonupayu/1/edit?html,js,output">demo</a> of the API in action.</p>
+            <p>Here's a <a href="https://jsbin.com/momonupayu/1/edit?html,js,output">demo</a> of the API in action.</p>
           </div>
         </div>
 
@@ -180,9 +180,9 @@ function App() {
           <div class="col-lg-9">
 
             <h1 id="tools">Tools</h1>
-            <p><a href="https://glyphsearch.com/" target="_blank">GlyphSearch</a> is a tool for searching icons from Glyphicons, Font Awesome, and other popular icon font libraries.</p>
-            <p><a href="https://thomaspark.co/projects/fontcdn/" target="_blank">FontCDN</a> is a tool for searching web fonts from Google Fonts.</p>
-            <p><a href="https://codepip.com" target="_blank">Codepip</a> has coding games for learning HTML, CSS, and JavaScript.</p>
+            <p><a href="https://glyphsearch.com/" rel="noopener" target="_blank">GlyphSearch</a> is a tool for searching icons from Glyphicons, Font Awesome, and other popular icon font libraries.</p>
+            <p><a href="https://thomaspark.co/projects/fontcdn/" rel="noopener" target="_blank">FontCDN</a> is a tool for searching web fonts from Google Fonts.</p>
+            <p><a href="https://codepip.com" rel="noopener" target="_blank">Codepip</a> has coding games for learning HTML, CSS, and JavaScript.</p>
 
             <h1 id="donate">Donate</h1>
             <p>Donations are gratefully accepted via <a href="https://github.com/sponsors/thomaspark/">GitHub</a> and <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=PU2DH4BMF9MWS&source=url">PayPal</a>.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,16 +4,16 @@
     <meta charset="utf-8">
     <title>Bootswatch: Free themes for Bootstrap</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="./4/materia/bootstrap.css" media="screen">
     <link rel="stylesheet" href="./_vendor/font-awesome/css/font-awesome.min.css">
     <link rel="stylesheet" href="./_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -27,7 +27,7 @@
   <body id="home">
     <div class="navbar navbar-expand-lg fixed-top navbar-dark bg-primary navbar-transparent">
       <div class="container">
-          <a href="./" class="navbar-brand"><img src="_assets/img/logo-nav.svg"> Bootswatch</a>
+        <a href="./" class="navbar-brand"><img src="_assets/img/logo-nav.svg" alt=""> Bootswatch</a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -92,7 +92,7 @@
             <div class="row">
               <div class="col-md-6 mx-auto">
                 <div class="sponsor">
-                  <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+                  <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
                 </div>
               </div>
             </div>
@@ -148,7 +148,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="cerulean/"><img src="cerulean/thumbnail.png" class="img-responsive" alt="Cerulean"></a>
+                <a href="cerulean/"><img src="cerulean/thumbnail.png" class="img-fluid" alt="Cerulean"></a>
               </div>
               <div class="options">
                 <h3>Cerulean</h3>
@@ -174,7 +174,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="cosmo/"><img class="img-responsive" src="cosmo/thumbnail.png" alt="Cosmo"></a>
+                <a href="cosmo/"><img class="img-fluid" src="cosmo/thumbnail.png" alt="Cosmo"></a>
               </div>
               <div class="options">
                 <h3>Cosmo</h3>
@@ -200,7 +200,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="cyborg/"><img class="img-responsive" src="cyborg/thumbnail.png" alt="Cyborg"></a>
+                <a href="cyborg/"><img class="img-fluid" src="cyborg/thumbnail.png" alt="Cyborg"></a>
               </div>
               <div class="options">
                 <h3>Cyborg</h3>
@@ -226,7 +226,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="darkly/"><img class="img-responsive" src="darkly/thumbnail.png" alt="Darkly"></a>
+                <a href="darkly/"><img class="img-fluid" src="darkly/thumbnail.png" alt="Darkly"></a>
               </div>
               <div class="options">
                 <h3>Darkly</h3>
@@ -252,7 +252,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="flatly/"><img class="img-responsive" src="flatly/thumbnail.png" alt="Flatly"></a>
+                <a href="flatly/"><img class="img-fluid" src="flatly/thumbnail.png" alt="Flatly"></a>
               </div>
               <div class="options">
                 <h3>Flatly</h3>
@@ -278,7 +278,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="journal/"><img class="img-responsive" src="journal/thumbnail.png" alt="Journal"></a>
+                <a href="journal/"><img class="img-fluid" src="journal/thumbnail.png" alt="Journal"></a>
               </div>
               <div class="options">
                 <h3>Journal</h3>
@@ -304,7 +304,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="litera/"><img class="img-responsive" src="litera/thumbnail.png" alt="Litera"></a>
+                <a href="litera/"><img class="img-fluid" src="litera/thumbnail.png" alt="Litera"></a>
               </div>
               <div class="options">
                 <h3>Litera</h3>
@@ -330,7 +330,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="lumen/"><img src="lumen/thumbnail.png" class="img-responsive" alt="Lumen"></a>
+                <a href="lumen/"><img src="lumen/thumbnail.png" class="img-fluid" alt="Lumen"></a>
               </div>
               <div class="options">
                 <h3>Lumen</h3>
@@ -356,7 +356,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="lux/"><img src="lux/thumbnail.png" class="img-responsive" alt="Lux"></a>
+                <a href="lux/"><img src="lux/thumbnail.png" class="img-fluid" alt="Lux"></a>
               </div>
               <div class="options">
                 <h3>Lux</h3>
@@ -382,7 +382,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="materia/"><img class="img-responsive" src="materia/thumbnail.png" alt="Materia"></a>
+                <a href="materia/"><img class="img-fluid" src="materia/thumbnail.png" alt="Materia"></a>
               </div>
               <div class="options">
                 <h3>Materia</h3>
@@ -408,7 +408,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="minty/"><img src="minty/thumbnail.png" class="img-responsive" alt="Minty"></a>
+                <a href="minty/"><img src="minty/thumbnail.png" class="img-fluid" alt="Minty"></a>
               </div>
               <div class="options">
                 <h3>Minty</h3>
@@ -434,7 +434,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="pulse/"><img src="pulse/thumbnail.png" class="img-responsive" alt="Pulse"></a>
+                <a href="pulse/"><img src="pulse/thumbnail.png" class="img-fluid" alt="Pulse"></a>
               </div>
               <div class="options">
                 <h3>Pulse</h3>
@@ -460,7 +460,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="sandstone/"><img src="sandstone/thumbnail.png" class="img-responsive" alt="Sandstone"></a>
+                <a href="sandstone/"><img src="sandstone/thumbnail.png" class="img-fluid" alt="Sandstone"></a>
               </div>
               <div class="options">
                 <h3>Sandstone</h3>
@@ -486,7 +486,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="simplex/"><img class="img-responsive" src="simplex/thumbnail.png" alt="Simplex"></a>
+                <a href="simplex/"><img class="img-fluid" src="simplex/thumbnail.png" alt="Simplex"></a>
               </div>
               <div class="options">
                 <h3>Simplex</h3>
@@ -512,7 +512,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="sketchy/"><img class="img-responsive" src="sketchy/thumbnail.png" alt="Sketchy"></a>
+                <a href="sketchy/"><img class="img-fluid" src="sketchy/thumbnail.png" alt="Sketchy"></a>
               </div>
               <div class="options">
                 <h3>Sketchy</h3>
@@ -538,7 +538,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="slate/"><img class="img-responsive" src="slate/thumbnail.png" alt="Slate"></a>
+                <a href="slate/"><img class="img-fluid" src="slate/thumbnail.png" alt="Slate"></a>
               </div>
               <div class="options">
                 <h3>Slate</h3>
@@ -565,7 +565,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="solar/"><img class="img-responsive" src="solar/thumbnail.png" alt="Solar"></a>
+                <a href="solar/"><img class="img-fluid" src="solar/thumbnail.png" alt="Solar"></a>
               </div>
               <div class="options">
                 <h3>Solar</h3>
@@ -592,7 +592,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="spacelab/"><img class="img-responsive" src="spacelab/thumbnail.png" alt="Spacelab"></a>
+                <a href="spacelab/"><img class="img-fluid" src="spacelab/thumbnail.png" alt="Spacelab"></a>
               </div>
               <div class="options">
                 <h3>Spacelab</h3>
@@ -618,7 +618,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="superhero/"><img class="img-responsive" src="superhero/thumbnail.png" alt="Superhero"></a>
+                <a href="superhero/"><img class="img-fluid" src="superhero/thumbnail.png" alt="Superhero"></a>
               </div>
               <div class="options">
                 <h3>Superhero</h3>
@@ -644,7 +644,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="united/"><img class="img-responsive" src="united/thumbnail.png" alt="United"></a>
+                <a href="united/"><img class="img-fluid" src="united/thumbnail.png" alt="United"></a>
               </div>
               <div class="options">
                 <h3>United</h3>
@@ -670,7 +670,7 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="yeti/"><img class="img-responsive" src="yeti/thumbnail.png" alt="Yeti"></a>
+                <a href="yeti/"><img class="img-fluid" src="yeti/thumbnail.png" alt="Yeti"></a>
               </div>
               <div class="options">
                 <h3>Yeti</h3>
@@ -703,19 +703,19 @@
         <div class="row">
           <div class="col-lg-12">
             <h1>Want more?</h1>
-            <p class="lead">Check out these premium templates from <a target="_blank" href="https://gumroad.com/a/862303347" title="Marketplace for premium Bootstrap templates" onclick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', '3rdwave']);">3rd Wave Media</a>.</p>
+            <p class="lead">Check out these premium templates from <a rel="noopener" target="_blank" href="https://gumroad.com/a/862303347" title="Marketplace for premium Bootstrap templates" onclick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', '3rdwave']);">3rd Wave Media</a>.</p>
           </div>
 
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" class="img-responsive" href="https://gumroad.com/a/233731187" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'launch']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_launch-bootstrap-template-for-saas-businesses.png" alt="Launch"></a>
+                <a rel="noopener" target="_blank" class="img-fluid" href="https://gumroad.com/a/233731187" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'launch']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_launch-bootstrap-template-for-saas-businesses.png" alt="Launch"></a>
               </div>
               <div class="options">
                 <h3>Launch</h3>
                 <p>A template for SaaS businesses</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/233731187" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'launch']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/233731187" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'launch']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -724,13 +724,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" class="img-responsive" href="https://gumroad.com/a/929412211" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'instance']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_instance-bootstrap-portfolio-template-for-developers.png" alt="Instance"></a>
+                <a rel="noopener" target="_blank" class="img-fluid" href="https://gumroad.com/a/929412211" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'instance']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_instance-bootstrap-portfolio-template-for-developers.png" alt="Instance"></a>
               </div>
               <div class="options">
                 <h3>Instance</h3>
                 <p>A personal portfolio template for developers</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/929412211" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'instance']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/929412211" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'instance']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -739,13 +739,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" class="img-responsive" href="https://gumroad.com/a/927839347" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'startupkit']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_startupkit-startup-bootstrap-template.png" alt="Startup Kit"></a>
+                <a rel="noopener" target="_blank" class="img-fluid" href="https://gumroad.com/a/927839347" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'startupkit']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_startupkit-startup-bootstrap-template.png" alt="Startup Kit"></a>
               </div>
               <div class="options">
                 <h3>Startup Kit</h3>
                 <p>A Bootstrap template for SaaS startups</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/927839347" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'startupkit']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/927839347" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'startupkit']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -754,13 +754,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" href="https://gumroad.com/a/392541299" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'coderpro']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_coderpro_bs4_-700.png" alt="CoderPro"></a>
+                <a rel="noopener" target="_blank" href="https://gumroad.com/a/392541299" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'coderpro']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_coderpro_bs4_-700.png" alt="CoderPro"></a>
               </div>
               <div class="options">
                 <h3>CoderPro</h3>
                 <p>Startup template for software projects</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/392541299" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'coderpro']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/392541299" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'coderpro']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -769,13 +769,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" href="https://gumroad.com/a/1063629939" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'novapro']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_nova-pro_bs4_-700.png" alt="Nova Pro"></a>
+                <a rel="noopener" target="_blank" href="https://gumroad.com/a/1063629939" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'novapro']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_nova-pro_bs4_-700.png" alt="Nova Pro"></a>
               </div>
               <div class="options">
                 <h3>Nova Pro</h3>
                 <p>The best way to promote your mobile app</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/1063629939" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'novapro']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/1063629939" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'novapro']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -784,13 +784,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a target="_blank" class="img-responsive" href="https://gumroad.com/a/145077363" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'devcard']);"><img class="img-responsive" src="_assets/img/refs/themes.3rdwavemedia.com_devcard_bs4_2.0_-700.png" alt="Dev Card"></a>
+                <a rel="noopener" target="_blank" class="img-fluid" href="https://gumroad.com/a/145077363" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'devcard']);"><img class="img-fluid" src="_assets/img/refs/themes.3rdwavemedia.com_devcard_bs4_2.0_-700.png" alt="Dev Card"></a>
               </div>
               <div class="options">
                 <h3>Dev Card</h3>
                 <p>A portfolio template for developers</p>
                 <div>
-                  <a class="btn btn-primary" target="_blank" href="https://gumroad.com/a/145077363" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'devcard']);">View Details</a>
+                  <a class="btn btn-primary" rel="noopener" target="_blank" href="https://gumroad.com/a/145077363" onClick="_gaq.push(['_trackEvent', 'outbound', '3rdwave', 'devcard']);">View Details</a>
                 </div>
               </div>
             </div>
@@ -801,19 +801,19 @@
         <div class="row">
           <div class="col-lg-12">
             <h1>Still looking?</h1>
-            <p class="lead">Learn to code your own themes with these books from <a target="_blank" rel="nofollow" href="https://www.amazon.com/?tag=bootswatch-20">Amazon</a>. As an associate, we earn a cut of each sale.</p>
+            <p class="lead">Learn to code your own themes with these books from <a rel="noopener nofollow" target="_blank" href="https://www.amazon.com/?tag=bootswatch-20">Amazon</a>. As an associate, we earn a cut of each sale.</p>
           </div>
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'htmlandcss']);" rel="nofollow" href="https://www.amazon.com/gp/product/1118907442/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1118907442" target="_blank"><img class="img-responsive" src="_assets/img/refs/htmlandcss.png" alt="HTML and CSS: Design and Build Websites, by Jon Duckett"></a>
+                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'htmlandcss']);" href="https://www.amazon.com/gp/product/1118907442/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1118907442" rel="noopener nofollow" target="_blank"><img class="img-fluid" src="_assets/img/refs/htmlandcss.png" alt="HTML and CSS: Design and Build Websites, by Jon Duckett"></a>
               </div>
               <div class="options">
                 <h3>HTML &amp; CSS</h3>
                 <p>Jon Duckett</p>
                 <div>
-                  <img src="//ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1118907442" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />
-                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'htmlandcss']);" rel="nofollow" href="https://www.amazon.com/gp/product/1118907442/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1118907442" target="_blank">Buy Now</a></div>
+                  <img src="https://ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1118907442" width="1" height="1" alt="" style="border:none !important; margin:0 !important;">
+                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'htmlandcss']);" href="https://www.amazon.com/gp/product/1118907442/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1118907442" rel="noopener nofollow" target="_blank">Buy Now</a></div>
                 </div>
               </div>
             </div>
@@ -821,14 +821,14 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'eloquentjavascript']);" rel="nofollow" href="https://www.amazon.com/gp/product/1593279507/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1593279507" target="_blank"><img class="img-responsive" src="_assets/img/refs/eloquentjavascript.png" alt="Eloquent JavaScript, by Marijn Haverbeke"></a>
+                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'eloquentjavascript']);" href="https://www.amazon.com/gp/product/1593279507/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1593279507" rel="noopener nofollow" target="_blank"><img class="img-fluid" src="_assets/img/refs/eloquentjavascript.png" alt="Eloquent JavaScript, by Marijn Haverbeke"></a>
               </div>
               <div class="options">
                 <h3>Eloquent JavaScript</h3>
                 <p>Marijn Haverbeke</p>
                 <div>
-                  <img src="//ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1593279507" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />
-                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'eloquentjavascript']);" rel="nofollow" href="https://www.amazon.com/gp/product/1593279507/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1593279507" target="_blank">Buy Now</a></div>
+                  <img src="https://ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1593279507" width="1" height="1" alt="" style="border:none !important; margin:0 !important;">
+                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'eloquentjavascript']);" href="https://www.amazon.com/gp/product/1593279507/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1593279507" rel="noopener nofollow" target="_blank">Buy Now</a></div>
                 </div>
               </div>
             </div>
@@ -836,14 +836,14 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'csssecrets']);" rel="nofollow" href="https://www.amazon.com/gp/product/1449372635/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1449372635" target="_blank"><img class="img-responsive" src="_assets/img/refs/csssecrets.png" alt="CSS Secrets: Better Solutions to Everyday Web Design Problems by Lea Verou"></a>
+                <a onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'csssecrets']);" href="https://www.amazon.com/gp/product/1449372635/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1449372635" rel="noopener nofollow" target="_blank"><img class="img-fluid" src="_assets/img/refs/csssecrets.png" alt="CSS Secrets: Better Solutions to Everyday Web Design Problems by Lea Verou"></a>
               </div>
               <div class="options">
                 <h3>CSS Secrets</h3>
                 <p>Lea Verou</p>
                 <div>
-                  <img src="//ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1449372635" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" />
-                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'csssecrets']);" rel="nofollow" href="https://www.amazon.com/gp/product/1449372635/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1449372635" target="_blank">Buy Now</a></div>
+                  <img src="https://ir-na.amazon-adsystem.com/e/ir?t=bootswatch-20&l=am2&o=1&a=1449372635" width="1" height="1" alt="" style="border:none !important; margin:0 !important;">
+                  <div class="btn-group"><a class="btn btn-primary" onClick="_gaq.push(['_trackEvent', 'outbound', 'amazon', 'csssecrets']);" href="https://www.amazon.com/gp/product/1449372635/ref=as_li_tf_tl?ie=UTF8&amp;tag=bootswatch-20&amp;linkCode=as2&amp;camp=1789&amp;creative=9325&amp;creativeASIN=1449372635" rel="noopener nofollow" target="_blank">Buy Now</a></div>
                 </div>
               </div>
             </div>
@@ -853,18 +853,18 @@
         <div class="row">
           <div class="col-lg-12">
             <h1>Good luck have fun!</h1>
-            <p class="lead">Or learn to code by playing games with <a target="_blank" href="https://codepip.com">Codepip</a>.</p>
+            <p class="lead">Or learn to code by playing games with <a rel="noopener" target="_blank" href="https://codepip.com">Codepip</a>.</p>
           </div>
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="https://codepip.com/games/flexbox-froggy/" target="_blank"><img class="img-responsive" src="_assets/img/refs/flexbox-froggy-pro.png" alt="Flexbox Froggy: A game for learning CSS Flexbox"></a>
+                <a href="https://codepip.com/games/flexbox-froggy/" rel="noopener" target="_blank"><img class="img-fluid" src="_assets/img/refs/flexbox-froggy-pro.png" alt="Flexbox Froggy: A game for learning CSS Flexbox"></a>
               </div>
               <div class="options">
                 <h3>Flexbox Froggy</h3>
                 <p>A game for learning CSS Flexbox</p>
                 <div>
-                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/flexbox-froggy/" target="_blank">Play Now</a></div>
+                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/flexbox-froggy/" rel="noopener" target="_blank">Play Now</a></div>
                 </div>
               </div>
             </div>
@@ -872,13 +872,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="https://codepip.com/games/grid-garden/" target="_blank"><img class="img-responsive" src="_assets/img/refs/grid-garden.png" alt="Grid Garden: A game for learning CSS Grid"></a>
+                <a href="https://codepip.com/games/grid-garden/" rel="noopener" target="_blank"><img class="img-fluid" src="_assets/img/refs/grid-garden.png" alt="Grid Garden: A game for learning CSS Grid"></a>
               </div>
               <div class="options">
                 <h3>Grid Garden</h3>
                 <p>A game for learning CSS Grid</p>
                 <div>
-                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/grid-garden/" target="_blank">Play Now</a></div>
+                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/grid-garden/" rel="noopener" target="_blank">Play Now</a></div>
                 </div>
               </div>
             </div>
@@ -886,13 +886,13 @@
           <div class="col-lg-4 col-sm-6">
             <div class="preview">
               <div class="image">
-                <a href="https://codepip.com/games/code-crunchers/" target="_blank"><img class="img-responsive" src="_assets/img/refs/code-crunchers.png" alt="Code Crunchers: A game for learning JavaScript Math"></a>
+                <a href="https://codepip.com/games/code-crunchers/" rel="noopener" target="_blank"><img class="img-fluid" src="_assets/img/refs/code-crunchers.png" alt="Code Crunchers: A game for learning JavaScript Math"></a>
               </div>
               <div class="options">
                 <h3>Code Crunchers</h3>
                 <p>A game for learning JavaScript Math</p>
                 <div>
-                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/code-crunchers/" target="_blank">Play Now</a></div>
+                  <div class="btn-group"><a class="btn btn-primary" href="https://codepip.com/games/code-crunchers/" rel="noopener" target="_blank">Play Now</a></div>
                 </div>
               </div>
             </div>

--- a/docs/journal/index.html
+++ b/docs/journal/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Journal</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/journal/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Journal <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/uyeaokyd/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/uyeaokyd/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/journal/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/journal/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/litera/index.html
+++ b/docs/litera/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Litera</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/litera/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Litera <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/rnjfzjjo/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/rnjfzjjo/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/litera/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/litera/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/lumen/index.html
+++ b/docs/lumen/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Lumen</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/lumen/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Lumen <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/gqhenoox/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/gqhenoox/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/lumen/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/lumen/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/lux/index.html
+++ b/docs/lux/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Lux</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/lux/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Lux <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/8zet8yhz/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/8zet8yhz/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/lux/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/lux/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/materia/index.html
+++ b/docs/materia/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Materia</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/materia/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Materia <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/ndax7sh7/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/ndax7sh7/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/materia/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/materia/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/minty/index.html
+++ b/docs/minty/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Minty</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/minty/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Minty <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/3bojykn2/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/3bojykn2/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/minty/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/minty/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/pulse/index.html
+++ b/docs/pulse/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Pulse</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/pulse/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Pulse <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/0mb9487u/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/0mb9487u/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/pulse/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/pulse/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/sandstone/index.html
+++ b/docs/sandstone/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Sandstone</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/sandstone/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Sandstone <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/m0nv7a0o/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/m0nv7a0o/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/sandstone/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/sandstone/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/simplex/index.html
+++ b/docs/simplex/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Simplex</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/simplex/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Simplex <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/3he50zsf/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/3he50zsf/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/simplex/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/simplex/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/sketchy/index.html
+++ b/docs/sketchy/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Sketchy</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/sketchy/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Sketchy <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/gbuemo39/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/gbuemo39/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/sketchy/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/sketchy/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/slate/index.html
+++ b/docs/slate/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Slate</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/slate/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Slate <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/g1q7jxzf/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/g1q7jxzf/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/slate/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/slate/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Solar</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/solar/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Solar <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/mqoc3ah6/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/mqoc3ah6/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/solar/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/solar/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/spacelab/index.html
+++ b/docs/spacelab/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Spacelab</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/spacelab/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Spacelab <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/Laobkr1d/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/Laobkr1d/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/spacelab/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/spacelab/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/superhero/index.html
+++ b/docs/superhero/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Superhero</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/superhero/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Superhero <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/9n4nxnqy/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/9n4nxnqy/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/superhero/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/superhero/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/united/index.html
+++ b/docs/united/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: United</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/united/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">United <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/cvLkpsx0/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/cvLkpsx0/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/united/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/united/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>

--- a/docs/yeti/index.html
+++ b/docs/yeti/index.html
@@ -4,15 +4,15 @@
     <meta charset="utf-8">
     <title>Bootswatch: Yeti</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="stylesheet" href="../4/yeti/bootstrap.css" media="screen">
     <link rel="stylesheet" href="../_assets/css/custom.min.css">
     <script>
 
-     var _gaq = _gaq || [];
+       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-23019901-1']);
-      _gaq.push(['_setDomainName', "bootswatch.com"]);
-        _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_setDomainName', 'bootswatch.com']);
+      _gaq.push(['_setAllowLinker', true]);
       _gaq.push(['_trackPageview']);
 
      (function() {
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="download">Yeti <span class="caret"></span></a>
               <div class="dropdown-menu" aria-labelledby="download">
-                <a class="dropdown-item" target="_blank" href="https://jsfiddle.net/bootswatch/vdr1vx77/">Open in JSFiddle</a>
+                <a class="dropdown-item" rel="noopener" target="_blank" href="https://jsfiddle.net/bootswatch/vdr1vx77/">Open in JSFiddle</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" href="../4/yeti/bootstrap.min.css" download>bootstrap.min.css</a>
                 <a class="dropdown-item" href="../4/yeti/bootstrap.css" download>bootstrap.css</a>
@@ -95,7 +95,7 @@
           </div>
           <div class="col-lg-4 col-md-5 col-sm-6">
             <div class="sponsor">
-              <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
+              <script async src="https://cdn.carbonads.com/carbon.js?serve=CKYIE23N&placement=bootswatchcom" id="_carbonads_js"></script>
             </div>
           </div>
         </div>
@@ -303,7 +303,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-info">Info</button>
                 <div class="btn-group" role="group">
@@ -314,7 +314,7 @@
                   </div>
                 </div>
               </div>
-              
+
               <div class="btn-group" role="group" aria-label="Button group with nested dropdown">
                 <button type="button" class="btn btn-danger">Danger</button>
                 <div class="btn-group" role="group">
@@ -582,7 +582,7 @@
                     <td>Column content</td>
                   </tr>
                 </tbody>
-              </table> 
+              </table>
             </div><!-- /example -->
           </div>
         </div>


### PR DESCRIPTION
* use https when possible (Google Analytics is left)
* use `img-fluid` since `img-responsive` is a v3 class
* specify `rel="noopener"` for external links
* trim trailing spaces
* remove unneeded HTML end tags
* remove the unneeded `type=text/javascript`
* remove the obsolete `border="0"`

----

* Preview: <https://nifty-jepsen-0a9dc7.netlify.app/>
* Non-whitespace diff: <https://github.com/thomaspark/bootswatch/pull/978/files?w=1>

----

@thomaspark some notes:

1. might be a good chance to update the Google Analytics snippet and related `onClick` code to the new one
2. I didn't apply all the changes to the v2 and v3 docs, only the https change for the mixed content errors
3. You can probably remove `max-width: 100%` from your custom Sass code since `img-fluid` is used now