### PR TITLE
cosmo: fix fonts.

### DIFF
--- a/dist/cosmo/_variables.scss
+++ b/dist/cosmo/_variables.scss
@@ -47,7 +47,7 @@ $body-color:    $gray-800 !default;
 
 // Fonts
 
-$font-family-sans-serif: "Segoe UI", "Source Sans Pro", Calibri, Candara, Arial, sans-serif !default;
+$font-family-sans-serif: "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default !default;
 
 $font-size-base: 0.9375rem !default;
 


### PR DESCRIPTION
Previously Segoe UI was declared first.

@thomaspark let me know if you intentionally had left out the other fonts. But Open Sans Pro should come first otherwise is not used on Windows since Segoe UI was first.