### PR TITLE
materia: use the decoded SVG and remove charset.

### DIFF
--- a/dist/materia/_variables.scss
+++ b/dist/materia/_variables.scss
@@ -94,7 +94,7 @@ $custom-checkbox-indicator-border-radius: 2px !default;
 
 $custom-control-indicator-disabled-bg: $gray-100 !default;
 
-$custom-radio-indicator-icon-checked: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='4' fill='%232196F3'/%3E%3C/svg%3E") !default;
+$custom-radio-indicator-icon-checked: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'><circle r='4' fill='#2196f3'/></svg>") !default;
 
 $custom-select-border-radius:       0 !default;
 $custom-select-box-shadow:          none !default;


### PR DESCRIPTION
Bootstrap already escapes these characters, and charset is unneeded.

Generated CSS diff:

```diff
 dist/materia/bootstrap.css | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

diff --git a/dist/materia/bootstrap.css b/dist/materia/bootstrap.css
index dbb97c83..55dd0a00 100644
--- a/dist/materia/bootstrap.css
+++ b/dist/materia/bootstrap.css
@@ -3880,7 +3880,7 @@ input[type="button"].btn-block {
 }
 
 .custom-radio .custom-control-input:checked ~ .custom-control-label::after {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3E%3Ccircle r='4' fill='%232196F3'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='4' fill='%232196f3'/%3e%3c/svg%3e");
 }
 
 .custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {

````