### PR TITLE
Don't set (unused) $input-btn-border-width in lux theme

### DIFF
--- a/dist/lux/_variables.scss
+++ b/dist/lux/_variables.scss
@@ -65,9 +65,6 @@ $headings-color:              $gray-900 !default;
 
 $table-border-color:          rgba(0, 0, 0, .05) !default;
 
-// Buttons + Forms
-
-$input-btn-border-width:      0 !default;
 
 // Buttons
 


### PR DESCRIPTION
[Can cause issues](https://github.com/rstudio/bslib/issues/215) for other Sass code that listens to `$input-btn-border-width`