### PR TITLE
Add more text classes to table sample

### DIFF
--- a/docs/cerulean/index.html
+++ b/docs/cerulean/index.html
@@ -533,70 +533,92 @@
                   <tr>
                     <th scope="col">Type</th>
                     <th scope="col">Column heading</th>
-                    <th scope="col">Column heading</th>
-                    <th scope="col">Column heading</th>
+                    <th scope="col" class="text-success">Column heading success</th>
+                    <th scope="col" class="text-danger">Column heading danger</th>
+                    <th scope="col" class="text-warning">Column heading warning</th>
+                    <th scope="col" class="text-info">Column heading info</th>
                   </tr>
                 </thead>
                 <tbody>
                   <tr class="table-active">
                     <th scope="row">Active</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr>
                     <th scope="row">Default</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-primary">
                     <th scope="row">Primary</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-secondary">
                     <th scope="row">Secondary</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-success">
                     <th scope="row">Success</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-danger">
                     <th scope="row">Danger</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-warning">
                     <th scope="row">Warning</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-info">
                     <th scope="row">Info</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-light">
                     <th scope="row">Light</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                   <tr class="table-dark">
                     <th scope="row">Dark</th>
                     <td>Column content</td>
-                    <td>Column content</td>
-                    <td>Column content</td>
+                    <td class="text-success">Column content</td>
+                    <td class="text-danger">Column content</td>
+                    <td class="text-warning">Column content</td>
+                    <td class="text-info">Column content</td>
                   </tr>
                 </tbody>
               </table>


### PR DESCRIPTION
When testing different themes I remarked that dark themes had some trouble showing table with table-success and text-success.
I made changes on cerulean so you can have a preview of what I mean.