### PR TITLE
Update .browserslistrc to Bootstrap's v5 one

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,13 +1,11 @@
 # https://github.com/browserslist/browserslist#readme
 
->= 1%
-last 1 major version
+>= 0.5%
+last 2 major versions
 not dead
-Chrome >= 45
-Firefox >= 38
-Edge >= 12
-Explorer >= 10
-iOS >= 9
-Safari >= 9
-Android >= 4.4
-Opera >= 30
+Chrome >= 60
+Firefox >= 60
+Firefox ESR
+iOS >= 12
+Safari >= 12
+not Explorer <= 11


### PR DESCRIPTION
This should get rid of plenty of vendor prefixes which are useless since those browsers aren't supported by Bootstrap itself.