### PR TITLE
Fix Sass warning: Passing a number without unit % (0) is deprecated

### DIFF
--- a/dist/cyborg/_variables.scss
+++ b/dist/cyborg/_variables.scss
@@ -67,7 +67,7 @@ $table-border-color:            $gray-700 !default;
 $table-dark-bg:                 $gray-500 !default;
 $table-dark-border-color:       darken($gray-500, 7.5%) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/dist/darkly/_variables.scss
+++ b/dist/darkly/_variables.scss
@@ -63,7 +63,7 @@ $text-muted:                  $gray-600 !default;
 
 $table-border-color:          $gray-700 !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/dist/flatly/_variables.scss
+++ b/dist/flatly/_variables.scss
@@ -55,7 +55,7 @@ $h3-font-size:                2rem !default;
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Dropdowns
 

--- a/dist/litera/_variables.scss
+++ b/dist/litera/_variables.scss
@@ -59,7 +59,7 @@ $headings-font-weight:        700 !default;
 
 $table-border-color:          rgba(0, 0, 0, .1) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/dist/lumen/_variables.scss
+++ b/dist/lumen/_variables.scss
@@ -48,7 +48,7 @@ $font-family-sans-serif:      "Source Sans Pro", -apple-system, BlinkMacSystemFo
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/dist/minty/_variables.scss
+++ b/dist/minty/_variables.scss
@@ -61,7 +61,7 @@ $headings-color:              $gray-700 !default;
 
 $table-border-color:          rgba(0, 0, 0, .05) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Dropdowns
 
@@ -94,7 +94,7 @@ $pagination-disabled-border-color:  $pagination-disabled-bg !default;
 // Alerts
 
 $alert-color-scale:                 0% !default;
-$alert-bg-scale:                    0 !default;
+$alert-bg-scale:                    0% !default;
 
 // Breadcrumbs
 

--- a/dist/quartz/_variables.scss
+++ b/dist/quartz/_variables.scss
@@ -79,7 +79,7 @@ $blockquote-footer-color:     $text-muted !default;
 $table-dark-bg:               $dark !default;
 $table-dark-border-color:     darken($dark, 5%) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons + Forms
 

--- a/dist/slate/_variables.scss
+++ b/dist/slate/_variables.scss
@@ -61,7 +61,7 @@ $table-border-color:          rgba($black, .6) !default;
 $table-dark-border-color:     $table-border-color !default;
 $table-dark-color:            $white !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/dist/solar/_variables.scss
+++ b/dist/solar/_variables.scss
@@ -70,7 +70,7 @@ $table-dark-bg:               $gray-500 !default;
 $table-dark-border-color:     darken($gray-500, 3%) !default;
 $table-dark-color:            $body-bg !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/dist/superhero/_variables.scss
+++ b/dist/superhero/_variables.scss
@@ -69,7 +69,7 @@ $table-dark-bg:               $light !default;
 $table-dark-border-color:     $gray-200 !default;
 $table-dark-color:            $body-bg !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/dist/vapor/_variables.scss
+++ b/dist/vapor/_variables.scss
@@ -76,7 +76,7 @@ $blockquote-footer-color:     $text-muted !default;
 
 $table-color:                 $white !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/dist/yeti/_variables.scss
+++ b/dist/yeti/_variables.scss
@@ -55,7 +55,7 @@ $headings-font-weight:        300 !default;
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 
@@ -99,7 +99,7 @@ $badge-padding-x:                   1rem !default;
 
 $alert-link-font-weight:            400 !default;
 
-$alert-bg-scale:                    0 !default;
+$alert-bg-scale:                    0% !default;
 
 // Progress bars
 

--- a/docs/5/cyborg/_variables.scss
+++ b/docs/5/cyborg/_variables.scss
@@ -67,7 +67,7 @@ $table-border-color:            $gray-700 !default;
 $table-dark-bg:                 $gray-500 !default;
 $table-dark-border-color:       darken($gray-500, 7.5%) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/docs/5/darkly/_variables.scss
+++ b/docs/5/darkly/_variables.scss
@@ -63,7 +63,7 @@ $text-muted:                  $gray-600 !default;
 
 $table-border-color:          $gray-700 !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/docs/5/flatly/_variables.scss
+++ b/docs/5/flatly/_variables.scss
@@ -55,7 +55,7 @@ $h3-font-size:                2rem !default;
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Dropdowns
 

--- a/docs/5/litera/_variables.scss
+++ b/docs/5/litera/_variables.scss
@@ -59,7 +59,7 @@ $headings-font-weight:        700 !default;
 
 $table-border-color:          rgba(0, 0, 0, .1) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/docs/5/lumen/_variables.scss
+++ b/docs/5/lumen/_variables.scss
@@ -48,7 +48,7 @@ $font-family-sans-serif:      "Source Sans Pro", -apple-system, BlinkMacSystemFo
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/docs/5/minty/_variables.scss
+++ b/docs/5/minty/_variables.scss
@@ -61,7 +61,7 @@ $headings-color:              $gray-700 !default;
 
 $table-border-color:          rgba(0, 0, 0, .05) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Dropdowns
 
@@ -94,7 +94,7 @@ $pagination-disabled-border-color:  $pagination-disabled-bg !default;
 // Alerts
 
 $alert-color-scale:                 0% !default;
-$alert-bg-scale:                    0 !default;
+$alert-bg-scale:                    0% !default;
 
 // Breadcrumbs
 

--- a/docs/5/quartz/_variables.scss
+++ b/docs/5/quartz/_variables.scss
@@ -79,7 +79,7 @@ $blockquote-footer-color:     $text-muted !default;
 $table-dark-bg:               $dark !default;
 $table-dark-border-color:     darken($dark, 5%) !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons + Forms
 

--- a/docs/5/slate/_variables.scss
+++ b/docs/5/slate/_variables.scss
@@ -61,7 +61,7 @@ $table-border-color:          rgba($black, .6) !default;
 $table-dark-border-color:     $table-border-color !default;
 $table-dark-color:            $white !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 

--- a/docs/5/solar/_variables.scss
+++ b/docs/5/solar/_variables.scss
@@ -70,7 +70,7 @@ $table-dark-bg:               $gray-500 !default;
 $table-dark-border-color:     darken($gray-500, 3%) !default;
 $table-dark-color:            $body-bg !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/docs/5/superhero/_variables.scss
+++ b/docs/5/superhero/_variables.scss
@@ -69,7 +69,7 @@ $table-dark-bg:               $light !default;
 $table-dark-border-color:     $gray-200 !default;
 $table-dark-color:            $body-bg !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/docs/5/vapor/_variables.scss
+++ b/docs/5/vapor/_variables.scss
@@ -76,7 +76,7 @@ $blockquote-footer-color:     $text-muted !default;
 
 $table-color:                 $white !default;
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Forms
 

--- a/docs/5/yeti/_variables.scss
+++ b/docs/5/yeti/_variables.scss
@@ -55,7 +55,7 @@ $headings-font-weight:        300 !default;
 
 // Tables
 
-$table-bg-scale:              0 !default;
+$table-bg-scale:              0% !default;
 
 // Buttons
 
@@ -99,7 +99,7 @@ $badge-padding-x:                   1rem !default;
 
 $alert-link-font-weight:            400 !default;
 
-$alert-bg-scale:                    0 !default;
+$alert-bg-scale:                    0% !default;
 
 // Progress bars
 


### PR DESCRIPTION
Fix for Sass depreciation (Breaking Change: Strict Function Units): https://sass-lang.com/d/function-units.

This resolves the below build error:
"Deprecation $weight: Passing a number without unit % (0) is deprecated.
To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units"