### PR TITLE
Fix incorrect class for text-info-emphasis example

### DIFF
--- a/docs/simplex/index.html
+++ b/docs/simplex/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>


### PR DESCRIPTION
Line 586 was set to the "text-info" class incorrectly. The proper class should be "text-info-emphasis".