### PR TITLE
Fixing incorrect text-info-emphasis example for theme demos

### DIFF
--- a/docs/cerulean/index.html
+++ b/docs/cerulean/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/cosmo/index.html
+++ b/docs/cosmo/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/cyborg/index.html
+++ b/docs/cyborg/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/darkly/index.html
+++ b/docs/darkly/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/default/index.html
+++ b/docs/default/index.html
@@ -580,7 +580,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/flatly/index.html
+++ b/docs/flatly/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/journal/index.html
+++ b/docs/journal/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/litera/index.html
+++ b/docs/litera/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/lumen/index.html
+++ b/docs/lumen/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/lux/index.html
+++ b/docs/lux/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/materia/index.html
+++ b/docs/materia/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/minty/index.html
+++ b/docs/minty/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/morph/index.html
+++ b/docs/morph/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/pulse/index.html
+++ b/docs/pulse/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/quartz/index.html
+++ b/docs/quartz/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/sandstone/index.html
+++ b/docs/sandstone/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/simplex/index.html
+++ b/docs/simplex/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/sketchy/index.html
+++ b/docs/sketchy/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/slate/index.html
+++ b/docs/slate/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/spacelab/index.html
+++ b/docs/spacelab/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/superhero/index.html
+++ b/docs/superhero/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/united/index.html
+++ b/docs/united/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/vapor/index.html
+++ b/docs/vapor/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/yeti/index.html
+++ b/docs/yeti/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>

--- a/docs/zephyr/index.html
+++ b/docs/zephyr/index.html
@@ -583,7 +583,7 @@
               <p class="text-warning">.text-warning</p>
               <p class="text-warning-emphasis">.text-warning-emphasis</p>
               <p class="text-info">.text-info</p>
-              <p class="text-info">.text-info-emphasis</p>
+              <p class="text-info-emphasis">.text-info-emphasis</p>
               <p class="text-light">.text-light</p>
               <p class="text-light">.text-light-emphasis</p>
               <p class="text-dark">.text-dark</p>


### PR DESCRIPTION
Summary: The ```text-info-emphasis``` example was missing the ```-emphasis``` suffix from its class definition. Here is a pull request to fix all examples.

Old: ```<p class="text-info">.text-info-emphasis</p>```
New: ```<p class="text-info-emphasis">.text-info-emphasis</p>```

Files Affected:
modified:   docs/cerulean/index.html
modified:   docs/cosmo/index.html
modified:   docs/cyborg/index.html
modified:   docs/darkly/index.html
modified:   docs/default/index.html
modified:   docs/flatly/index.html
modified:   docs/journal/index.html
modified:   docs/litera/index.html
modified:   docs/lumen/index.html
modified:   docs/lux/index.html
modified:   docs/materia/index.html
modified:   docs/minty/index.html
modified:   docs/morph/index.html
modified:   docs/pulse/index.html
modified:   docs/quartz/index.html
modified:   docs/sandstone/index.html
modified:   docs/simplex/index.html
modified:   docs/sketchy/index.html
modified:   docs/slate/index.html
modified:   docs/solar/index.html
modified:   docs/spacelab/index.html
modified:   docs/superhero/index.html
modified:   docs/united/index.html
modified:   docs/vapor/index.html
modified:   docs/yeti/index.html
modified:   docs/zephyr/index.html