### PR TITLE
Fix unreadable text on disabled secondary outline buttons in Lux theme

### DIFF
--- a/dist/lux/_bootswatch.scss
+++ b/dist/lux/_bootswatch.scss
@@ -71,6 +71,12 @@ $web-font-path: "https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;6
   border-color: $gray-600;
   color: $gray-600;
 
+  &.disabled,
+  &:disabled {
+    color: $gray-600;
+    background-color: transparent;
+  }
+  
   &:not([disabled]):not(.disabled):hover,
   &:not([disabled]):not(.disabled):focus,
   &:not([disabled]):not(.disabled):active {


### PR DESCRIPTION
The Bootswatch Lux theme overrides the base `.btn-outline-secondary` styling but fails to provide specific overrides for the `.disabled` class and `:disabled` pseudo-class. Because of this omission, disabled buttons fall back to the default Bootstrap styles (white text on a transparent background), making the text invisible against light backgrounds.

Added explicit CSS/SCSS rules for `.btn-outline-secondary.disabled` and `&:disabled` to maintain the expected gray text color (`$gray-600`) and transparent background, while still inheriting Bootstrap's default disabled opacity.