### PR TITLE
Fix border-widths that crash Vite when compiling

### DIFF
--- a/dist/morph/_variables.scss
+++ b/dist/morph/_variables.scss
@@ -54,7 +54,7 @@ $link-color: darken($body-color, 20%) !default;
 
 // Components
 
-$border-width:                0 !default;
+$border-width:                0px !default;
 $border-color:                rgba(darken($body-bg, 50%), .1) !default;
 
 $border-radius-pill:          50rem !default;

--- a/dist/vapor/_variables.scss
+++ b/dist/vapor/_variables.scss
@@ -56,7 +56,7 @@ $link-color:                              $body-color !default;
 
 // Components
 
-$border-width:                0 !default;
+$border-width:                0px !default;
 
 $border-radius:               .15rem !default;
 $border-radius-sm:            .05rem !default;


### PR DESCRIPTION
I've been using `sassc` to build my CSS for ages, and bootswatch has been working great. However, I changed to Vite recently, and it would crash without any extra info when compiling the Vapor theme. I narrowed it down to this `$border-width` variable - if it's set to `0`, it crashes, if it's `0px` it works fine.

I don't know *why* this is the case either on the Vite or the Bootswatch side, but it does seem to fix it. I wondered if some calculation is done elsewhere inside Bootstrap using border-width that gets confused if the `px` specifier isn't included, perhaps.